### PR TITLE
Change references of deprecated stable/graylog

### DIFF
--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 1.7.1
+version: 1.7.2
 appVersion: 3.3.8
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:

--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 1.7.0
+version: 1.7.1
 appVersion: 3.3.8
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:

--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -15,7 +15,7 @@ To install the Graylog Chart with all dependencies
 ```bash
 kubectl create namespace graylog
 
-helm install --namespace "graylog" -n "graylog" stable/graylog
+helm install --namespace "graylog" -n "graylog" kongz/graylog
 ```
 
 ## Manually Install Dependencies
@@ -41,7 +41,7 @@ Note: There are many alternative Elasticsearch available on GitHub. If you found
 To install the Graylog Chart into your Kubernetes cluster (This Chart requires persistent volume by default, you may need to create a storage class before install chart.
 
 ```bash
-helm install --namespace "graylog" -n "graylog" stable/graylog \
+helm install --namespace "graylog" -n "graylog" kongz/graylog \
   --set tags.install-mongodb=false\
   --set tags.install-elasticsearch=false\
   --set graylog.mongodb.uri=mongodb://mongodb-mongodb-replicaset-0.mongodb-mongodb-replicaset.graylog.svc.cluster.local:27017/graylog?replicaSet=rs0 \
@@ -68,7 +68,7 @@ For example:
 Set cluster size to 5
 
 ```bash
-helm install --namespace "graylog" -n "graylog" --set graylog.replicas=5 stable/graylog
+helm install --namespace "graylog" -n "graylog" --set graylog.replicas=5 kongz/graylog
 ```
 
 The command above will install 1 master and 4 coordinating.

--- a/charts/graylog/templates/NOTES.txt
+++ b/charts/graylog/templates/NOTES.txt
@@ -31,7 +31,7 @@ To connect to your Graylog server:
 To send logs to graylog:
 
   NOTE: If `graylog.input` is empty, you cannot send logs from other services. Please make sure the value is not empty.
-        See https://github.com/helm/charts/tree/master/stable/graylog#input for detail
+        See https://github.com/KongZ/charts/tree/main/charts/graylog#input for detail
 
 {{- if .Values.graylog.input.tcp }}
 1. TCP


### PR DESCRIPTION
# What this PR does / why we need it
Graylog README references deprecated chart, not this one. This PR updates these references, and updates a link previously leading to old chart. 

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/{{ .GitHubOrg }}/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
