### PR TITLE
Fix mongodb

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,11 @@ jobs:
           chmod 700 get_helm.sh
           ./get_helm.sh
 
+      - name: Add dependency chart repos
+        run: |
+          helm repo add stable https://charts.helm.sh/stable
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.0.0
         env:

--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 1.7.0
+version: 1.7.1
 appVersion: 3.3.8
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:

--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -100,7 +100,7 @@ Or use chart dependencies with release name
 {{- else if .Values.graylog.mongodb.uri }}
     {{- .Values.graylog.mongodb.uri -}}
 {{- else }}
-    {{- printf "mongodb://%s-mongodb.%s.svc.cluster.local:27017/graylog?replicaSet=rs0" .Release.Name .Release.Namespace -}}
+    {{- printf "mongodb://%s-headless.%s.svc.cluster.local:27017/graylog?replicaSet=rs0" .Release.Name .Release.Namespace -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -100,7 +100,7 @@ Or use chart dependencies with release name
 {{- else if .Values.graylog.mongodb.uri }}
     {{- .Values.graylog.mongodb.uri -}}
 {{- else }}
-    {{- printf "mongodb://%s-headless.%s.svc.cluster.local:27017/graylog?replicaSet=rs0" .Release.Name .Release.Namespace -}}
+    {{- printf "mongodb://%s-mongodb-headless.%s.svc.cluster.local:27017/graylog?replicaSet=rs0" .Release.Name .Release.Namespace -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -305,7 +305,7 @@ graylog:
     # uri: mongodb://user:pass@host1:27017,host2:27017,host3:27017/graylog?replicaSet=rs01
     uri: ""
     # Allow mongodb uri to be fetched from a k8s secret
-    # {{ graylog.fullname }}-mongodb will be used as uriSecretName if left empty
+    # {{ graylog.fullname }}-headless will be used as uriSecretName if left empty
     uriSecretName: ""
     uriSecretKey: ""
 
@@ -395,14 +395,14 @@ elasticsearch:
   repository: "docker.elastic.co/elasticsearch/elasticsearch-oss"
   tag: "6.8.13"
   client:
-    replicas: 2
+    replicas: 1
   master:
-    replicas: 3
+    replicas: 1
   data:
-    replicas: 2
+    replicas: 1
   cluster:
     env:
-      MINIMUM_MASTER_NODES: 2
+      MINIMUM_MASTER_NODES: 1
     xpackEnable: false
 
 mongodb:


### PR DESCRIPTION
# What this PR does / why we need it
Bitnami mongodb replicaset changed the service name to `-headless`
Github action taking too long to run `ct install`. Reduce ES nodes to 1 to improve testing speed
