### PR TITLE
[graylog] Fix plugin location in graylog 4.0.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,6 @@ repos:
         pass_filenames: false
         types: ['file']
         files: '^charts/.*(\.ya?ml|\.tpl|\.helmignore|NOTES.txt)'
-        entry: -u 0 quay.io/helmpack/chart-testing:v3.1.1 ct
+        entry: -u 0 quay.io/helmpack/chart-testing:v3.3.1 ct
         args:
           - lint

--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 1.7.3
-appVersion: 3.3.8
+version: 1.7.4
+appVersion: 4.0.2
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:
   - graylog

--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -108,7 +108,7 @@ The following table lists the configurable parameters of the Graylog chart and t
 
 | Parameter                                      | Description                                                                                                                                           | Default                           |
 |------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------- |
-| `graylog.image.repository`                     | `graylog` image repository                                                                                                                            | `graylog/graylog:3.1`             |
+| `graylog.image.repository`                     | `graylog` image repository                                                                                                                            | `graylog/graylog:4.0.2-1`             |
 | `graylog.imagePullPolicy`                      | Image pull policy                                                                                                                                     | `IfNotPresent`                    |
 | `graylog.replicas`                             | The number of Graylog instances in the cluster. The chart will automatic create assign master to one of replicas                                      | `2`                               |
 | `graylog.resources`                            | CPU/Memory resource requests/limits                                                                                                                   | Memory: `1024Mi`, CPU: `500m`     |

--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -48,6 +48,7 @@ helm install --namespace "graylog" -n "graylog" kongz/graylog \
   --set tags.install-elasticsearch=false\
   --set graylog.mongodb.uri=mongodb://mongodb-mongodb-replicaset-0.mongodb-mongodb-replicaset.graylog.svc.cluster.local:27017/graylog?replicaSet=rs0 \
   --set graylog.elasticsearch.hosts=http://elasticsearch-client.graylog.svc.cluster.local:9200
+  --set graylog.elasticsearch.version=7
 ```
 
 After installation succeeds, you can get a status of Chart
@@ -107,8 +108,8 @@ graylog:
 The following table lists the configurable parameters of the Graylog chart and their default values.
 
 | Parameter                                      | Description                                                                                                                                           | Default                           |
-|------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------- |
-| `graylog.image.repository`                     | `graylog` image repository                                                                                                                            | `graylog/graylog:4.0.2-1`             |
+|------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------|
+| `graylog.image.repository`                     | `graylog` image repository                                                                                                                            | `graylog/graylog:4.0.2-1`         |
 | `graylog.imagePullPolicy`                      | Image pull policy                                                                                                                                     | `IfNotPresent`                    |
 | `graylog.replicas`                             | The number of Graylog instances in the cluster. The chart will automatic create assign master to one of replicas                                      | `2`                               |
 | `graylog.resources`                            | CPU/Memory resource requests/limits                                                                                                                   | Memory: `1024Mi`, CPU: `500m`     |
@@ -155,6 +156,7 @@ The following table lists the configurable parameters of the Graylog chart and t
 | `graylog.rootEmail`                            | Graylog root email.                                                                                                                                   |                                   |
 | `graylog.existingRootSecret`                   | Graylog existing root secret                                                                                                                          |                                   |
 | `graylog.rootTimezone`                         | Graylog root timezone.                                                                                                                                | `UTC`                             |
+| `graylog.elasticsearch.version`                | Graylog Elasticsearch version. You need to specify a value 6 or 7. It is required for Graylog >4.0.2                                                  | `6`                               |
 | `graylog.elasticsearch.hosts`                  | Graylog Elasticsearch host name. You need to specific where data will be stored.                                                                      |                                   |
 | `graylog.elasticsearch.uriSecretName`          | K8s secret name where elasticsearch hosts will be set from.                                                                                           | `{{ graylog.fullname }}-es`       |
 | `graylog.elasticsearch.uriSecretKey`           | K8s secret key name where elasticsearch hosts will be set from.                                                                                       |                                   |
@@ -178,7 +180,7 @@ The following table lists the configurable parameters of the Graylog chart and t
 | `graylog.journal.deleteBeforeStart`            | Delete all journal files before start Graylog                                                                                                         | `false`                           |
 | `graylog.init.resources`                       | Configure resource requests and limits for the Graylog StatefulSet initContainer                                                                      | `{}`                              |
 | `graylog.provisioner.enabled`                  | Enable optional Job to run an arbitrary Bash script                                                                                                   | `false`                           |
-| `graylog.provisioner.annotations`              | Graylog provisioner Job annotations                                                                                                                    | `{}`                              |
+| `graylog.provisioner.annotations`              | Graylog provisioner Job annotations                                                                                                                   | `{}`                              |
 | `graylog.provisioner.useGraylogServiceAccount` | Use the same ServiceAccount used by Graylog pod                                                                                                       | `false`                           |
 | `graylog.provisioner.script`                   | The contents of the provisioner Bash script                                                                                                           |                                   |
 | `graylog.sidecarContainers`                    | Sidecar containers to run in the server statefulset                                                                                                   | `[]`                              |

--- a/charts/graylog/templates/configmap.yaml
+++ b/charts/graylog/templates/configmap.yaml
@@ -196,9 +196,12 @@ data:
     # Interpolate
     sed 's/"/\\\"/g;s/.*/echo "&"/e' ${GRAYLOG_HOME}/config/graylog.conf > ${GRAYLOG_HOME}/graylog.conf.subst
   {{- end }}
+  {{- if .Values.graylog.elasticsearch.version }}
+    export GRAYLOG_ELASTICSEARCH_VERSION={{ .Values.graylog.elasticsearch.version }}
+  {{- end }}
     echo "Graylog Home ${GRAYLOG_HOME}"
     echo "Graylog Plugin Dir ${GRAYLOG_PLUGIN_DIR}"
-    echo "JVM Options ${GRAYLOG_SERVER_JAVA_OPTS}"
+    echo "Graylog Elasticsearch Version ${GRAYLOG_ELASTICSEARCH_VERSION}"
     "${JAVA_HOME}/bin/java" \
       ${GRAYLOG_SERVER_JAVA_OPTS} \
       -jar \

--- a/charts/graylog/templates/configmap.yaml
+++ b/charts/graylog/templates/configmap.yaml
@@ -79,7 +79,6 @@ data:
     root_username = {{ .Values.graylog.rootUsername }}
     root_email = {{ .Values.graylog.rootEmail }}
     root_timezone = {{ default "UTC" .Values.graylog.rootTimezone }}
-    plugin_dir = /usr/share/graylog/plugin
   {{- $externalUri := include "graylog.url" . }}
   {{- if contains ":2" .Values.graylog.image.repository }}
     rest_listen_uri = http://0.0.0.0:9000/api/
@@ -146,6 +145,9 @@ data:
     export GRAYLOG_HTTP_PUBLISH_URI="{{ template "graylog.formatUrl" (list . "$(hostname -f):9000/") }}"
 
     GRAYLOG_HOME=/usr/share/graylog
+    export GRAYLOG_PLUGIN_DIR=${GRAYLOG_HOME}/plugin
+    # Graylog 4.0.2 images move plugin dir to `plugins-default`
+    find ${GRAYLOG_HOME}/plugins-default/ -type f -exec cp {} ${GRAYLOG_PLUGIN_DIR} \;
     # Looking for Master IP
     MASTER_IP=`/k8s/kubectl --namespace {{ .Release.Namespace }} get pod -o jsonpath='{range .items[*]}{.metadata.name} {.status.podIP}{"\n"}{end}' -l graylog-role=master --field-selector=status.phase=Running|awk '{print $2}'`
     SELF_IP=`/k8s/kubectl --namespace {{ .Release.Namespace }} get pod $HOSTNAME -o jsonpath='{.status.podIP}'`
@@ -171,12 +173,12 @@ data:
     echo "Downloading Graylog Plugins..."
   {{- range .Values.graylog.plugins }}
     echo "Downloading {{ .url }} ..."
-    curl -s --location --retry 3 -o ${GRAYLOG_HOME}/plugin/{{ .name }} "{{ .url }}"
+    curl -s --location --retry 3 -o ${GRAYLOG_PLUGIN_DIR}/{{ .name }} "{{ .url }}"
   {{- end }}
   {{- end }}
   {{- if .Values.graylog.metrics.enabled }}
     echo "Downloading https://github.com/graylog-labs/graylog-plugin-metrics-reporter/releases/download/3.0.0/metrics-reporter-prometheus-3.0.0.jar ..."
-    curl -s --location --retry 3 -o ${GRAYLOG_HOME}/plugin/metrics-reporter-prometheus-3.0.0.jar "https://github.com/graylog-labs/graylog-plugin-metrics-reporter/releases/download/3.0.0/metrics-reporter-prometheus-3.0.0.jar"
+    curl -s --location --retry 3 -o ${GRAYLOG_PLUGIN_DIR}/metrics-reporter-prometheus-3.0.0.jar "https://github.com/graylog-labs/graylog-plugin-metrics-reporter/releases/download/3.0.0/metrics-reporter-prometheus-3.0.0.jar"
   {{- end }}
   {{- if .Values.graylog.geoip.enabled }}
     echo "Downloading Maxmind GeoLite2 ..."
@@ -195,6 +197,7 @@ data:
     sed 's/"/\\\"/g;s/.*/echo "&"/e' ${GRAYLOG_HOME}/config/graylog.conf > ${GRAYLOG_HOME}/graylog.conf.subst
   {{- end }}
     echo "Graylog Home ${GRAYLOG_HOME}"
+    echo "Graylog Plugin Dir ${GRAYLOG_PLUGIN_DIR}"
     echo "JVM Options ${GRAYLOG_SERVER_JAVA_OPTS}"
     "${JAVA_HOME}/bin/java" \
       ${GRAYLOG_SERVER_JAVA_OPTS} \

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -49,7 +49,7 @@ graylog:
 
   ## Number of Graylog instance
   ##
-  replicas: 2
+  replicas: 1
 
   ## Additional environment variables to be added to Graylog pods
   ##
@@ -292,6 +292,9 @@ graylog:
   existingRootSecret: ""
 
   elasticsearch:
+    ## Major version of the Elasticsearch version used. 
+    ## It is required by Graylog 4. See https://docs.graylog.org/en/4.0/pages/configuration/elasticsearch.html#available-elasticsearch-configuration-tunables
+    version: "6"
     ## List of Elasticsearch hosts Graylog should connect to.
     ## Need to be specified as a comma-separated list of valid URIs for the http ports of your elasticsearch nodes.
     ## If one or more of your elasticsearch hosts require authentication, include the credentials in each node URI that

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -292,7 +292,7 @@ graylog:
   existingRootSecret: ""
 
   elasticsearch:
-    ## Major version of the Elasticsearch version used. 
+    ## Major version of the Elasticsearch version used.
     ## It is required by Graylog 4. See https://docs.graylog.org/en/4.0/pages/configuration/elasticsearch.html#available-elasticsearch-configuration-tunables
     version: "6"
     ## List of Elasticsearch hosts Graylog should connect to.

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -44,7 +44,7 @@ graylog:
   ## Make sure you strict with the `x` version of Graylog where `x` is ${version}-${x}
   ##
   image:
-    repository: "graylog/graylog:3.3.8-1"
+    repository: "graylog/graylog:4.0.2-1"
     pullPolicy: "IfNotPresent"
 
   ## Number of Graylog instance

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -398,8 +398,9 @@ imagePullSecrets: []
 ## Specify Elasticsearch version from requirement dependencies. Ignore this seection if you install Elasticsearch manually.
 ## Note: Graylog 2.4 requires Elasticsearch version <= 5.6
 elasticsearch:
-  repository: "docker.elastic.co/elasticsearch/elasticsearch-oss"
-  tag: "6.8.13"
+  image:
+    repository: "docker.elastic.co/elasticsearch/elasticsearch-oss"
+    tag: "6.8.13"
   client:
     replicas: 1
   master:


### PR DESCRIPTION
# What this PR does / why we need it

- Graylog image 4.0.2-1 changes the plugin location. The entrypoint.sh need to update the location.
- Change default graylog image to 4.0.2-1 

# Which issue this PR fixes

- fixes #20 

# Special notes for your reviewer
This chart have a long journey before Graylog official image supports the Kubernetes. 
The reason why I wrote my own `entrypoint.sh` because the official image could not be run with custom configuration on Kubernetes. It will have a lot of work to on this chart in order to use official entrypoint. But this is considering on a road map.

# Checklist
- [x] [DCO](https://github.com/{{ .GitHubOrg }}/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
