### PR TITLE
Security: update chart to use graylog version with security update

### DIFF
--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 1.8.10
-appVersion: 4.1.3
+version: 1.8.11
+appVersion: 4.1.9
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:
   - graylog

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -54,7 +54,7 @@ graylog:
   ## Make sure you strict with the `x` version of Graylog where `x` is ${version}-${x}
   ##
   image:
-    repository: "graylog/graylog:4.1.3-1"
+    repository: "graylog/graylog:4.1.19-1"
     pullPolicy: "IfNotPresent"
 
   ## Number of Graylog instance

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -54,7 +54,7 @@ graylog:
   ## Make sure you strict with the `x` version of Graylog where `x` is ${version}-${x}
   ##
   image:
-    repository: "graylog/graylog:4.1.19-1"
+    repository: "graylog/graylog:4.1.9-1"
     pullPolicy: "IfNotPresent"
 
   ## Number of Graylog instance


### PR DESCRIPTION
This updates chart to use latest graylog in same 4.1 series, with the log4j update - to avoid issues on update (hopefully).
