### PR TITLE
Graylog 4.2

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,5 +21,6 @@ jobs:
           VALIDATE_YAML: false
           VALIDATE_KUBERNETES_KUBEVAL: false
           VALIDATE_GITLEAKS: false
+          VALIDATE_NATURAL_LANGUAGE: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 1.8.11
-appVersion: 4.1.3
+version: 1.9.0
+appVersion: 4.2.3
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:
   - graylog

--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -108,8 +108,9 @@ graylog:
 The following table lists the configurable parameters of the Graylog chart and their default values.
 
 | Parameter                                      | Description                                                                                                                                           | Default                           |
-| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
-| `graylog.image.repository`                     | `graylog` image repository                                                                                                                            | `graylog/graylog:4.0.2-1`         |
+|------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------|
+| `graylog.image.repository`                     | `graylog` image repository                                                                                                                            | `graylog/graylog`                 |
+| `graylog.image.repository.tag`                 | `graylog` image repository                                                                                                                            | `graylog/graylog:4.2.3-1`         |
 | `graylog.imagePullPolicy`                      | Image pull policy                                                                                                                                     | `IfNotPresent`                    |
 | `graylog.replicas`                             | The number of Graylog instances in the cluster. The chart will automatic create assign master to one of replicas                                      | `2`                               |
 | `graylog.resources`                            | CPU/Memory resource requests/limits                                                                                                                   | Memory: `1024Mi`, CPU: `500m`     |
@@ -125,7 +126,8 @@ The following table lists the configurable parameters of the Graylog chart and t
 | `graylog.envRaw`                               | Graylog server env variables in raw yaml format                                                                                                       | `{}`                              |
 | `graylog.podSecurityContext`                   | Set security context for defining privilege and accessing control settings entire Pod                                                                 | `{}`                              |
 | `graylog.securityContext`                      | Set security context for defining privilege and accessing control settings for Graylog container                                                      | `privileged: false`               |
-| `graylog.additionalJavaOpts`                   | Graylog service additional `JAVA_OPTS`                                                                                                                |                                   |
+| `graylog.javaOpts`                             | Graylog service `JAVA_OPTS`                                                                                                                           |                                   |
+| ~~graylog.additionalJavaOpts~~                 | Graylog service additional `JAVA_OPTS` (Replaced with `graylog.javaOpts`)                                                                             |                                   |
 | `graylog.service.type`                         | Kubernetes Service type                                                                                                                               | `ClusterIP`                       |
 | `graylog.service.port`                         | Graylog Service port                                                                                                                                  | `9000`                            |
 | `graylog.service.ports`                        | Graylog Service extra ports                                                                                                                           | `[]`                              |
@@ -302,7 +304,7 @@ The certificates will be mounted into the `/etc/graylog/server`, so Inputs (e.g.
 those certificates with the following Input API configuration:
 
 | Parameter      | Value                           |
-| -------------- | ------------------------------- |
+|----------------|---------------------------------|
 | tls_cert_file: | /etc/graylog/server/server.cert |
 | tls_enable:    | true                            |
 | tls_key_file:  | /etc/graylog/server/server.key  |

--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -110,11 +110,11 @@ The following table lists the configurable parameters of the Graylog chart and t
 | Parameter                                      | Description                                                                                                                                           | Default                           |
 |------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------|
 | `graylog.image.repository`                     | `graylog` image repository                                                                                                                            | `graylog/graylog`                 |
-| `graylog.image.repository.tag`                 | `graylog` image repository                                                                                                                            | `graylog/graylog:4.2.3-1`         |
+| `graylog.image.repository.tag`                 | `graylog` image repository                                                                                                                            | `4.2.3-1`         |
 | `graylog.imagePullPolicy`                      | Image pull policy                                                                                                                                     | `IfNotPresent`                    |
 | `graylog.replicas`                             | The number of Graylog instances in the cluster. The chart will automatic create assign master to one of replicas                                      | `2`                               |
 | `graylog.resources`                            | CPU/Memory resource requests/limits                                                                                                                   | Memory: `1024Mi`, CPU: `500m`     |
-| `graylog.heapSize`                             | Override Java heap size. If this value empty, chart will allocate heapsize using `-XX:+UseCGroupMemoryLimitForHeap`                                   |                                   |
+| `graylog.heapSize`                             | Override Java heap size. If this value empty, chart will allocate heap size using `-XX:+UseCGroupMemoryLimitForHeap`                                   |                                   |
 | `graylog.externalUri`                          | External URI that Graylog is available at                                                                                                             |                                   |
 | `graylog.externalUriTLS`                       | Using TLS offload on External URI? set this to `true` to get https:// on ExternalUri at                                                               |                                   |
 | `graylog.nodeSelector`                         | Graylog server pod assignment                                                                                                                         | `{}`                              |
@@ -311,7 +311,7 @@ those certificates with the following Input API configuration:
 
 ### Web HTTPS
 
-Graylog can be autoconfigured to run in HTTPS mode when provided certificates by setting the `graylog.tls.enabled` value to `true`.
+Graylog can be auto configured to run in HTTPS mode when provided certificates by setting the `graylog.tls.enabled` value to `true`.
 
 If the certificates are different than those provided above (different hostname for example), then the web-specific
 certificates can be added to `graylog.serverFiles` and you can configure the `graylog.tls.certPath` and `graylog.tls.keyPath` to match.

--- a/charts/graylog/templates/configmap.yaml
+++ b/charts/graylog/templates/configmap.yaml
@@ -175,6 +175,7 @@ data:
     else
       # When container was recreated or restart, MASTER_IP == SELF_IP, running as master and no need to change label graylog-role="master"
       if [ "$SELF_IP" == "$MASTER_IP" ];then
+        echo "Launching $HOSTNAME as master"
         export GRAYLOG_IS_MASTER="true"
       else
         # MASTER_IP != SELF_IP, running as coordinating

--- a/charts/graylog/templates/configmap.yaml
+++ b/charts/graylog/templates/configmap.yaml
@@ -80,7 +80,8 @@ data:
     root_email = {{ .Values.graylog.rootEmail }}
     root_timezone = {{ default "UTC" .Values.graylog.rootTimezone }}
   {{- $externalUri := include "graylog.url" . }}
-  {{- if contains ":2" .Values.graylog.image.repository }}
+  {{ $graylogVersion := .Values.graylog.image.tag | default .Chart.AppVersion }}
+  {{- if semverCompare "~2" ( $graylogVersion ) }}
     rest_listen_uri = http://0.0.0.0:9000/api/
     web_listen_uri = http://0.0.0.0:9000/
   {{- if $externalUri }}
@@ -141,24 +142,32 @@ data:
     prometheus_exporter_enabled = true
     prometheus_exporter_bind_address = 0.0.0.0:9833
   {{- end }}
-
+  {{- if .Values.graylog.trustedProxies }}
+    trusted_proxies = {{.Values.graylog.trustedProxies}}
+  {{- end }}
   {{- if .Values.graylog.config }}
 {{ .Values.graylog.config | indent 4 }}
   {{- end }}
   entrypoint.sh: |-
     #!/usr/bin/env bash
 
-    export GRAYLOG_HTTP_PUBLISH_URI="{{ template "graylog.formatUrl" (list . "$(hostname -f):9000/") }}"
-
     GRAYLOG_HOME=/usr/share/graylog
     export GRAYLOG_PLUGIN_DIR=${GRAYLOG_HOME}/plugin
     # Graylog 4.0.2 images move plugin dir to `plugins-default`
     find ${GRAYLOG_HOME}/plugins-default/ -type f -exec cp {} ${GRAYLOG_PLUGIN_DIR} \;
     # Looking for Master IP
-    MASTER_IP=`/k8s/kubectl --namespace {{ .Release.Namespace }} get pod -o jsonpath='{range .items[*]}{.metadata.name} {.status.podIP}{"\n"}{end}' -l graylog-role=master --field-selector=status.phase=Running|awk '{print $2}'`
-    SELF_IP=`/k8s/kubectl --namespace {{ .Release.Namespace }} get pod $HOSTNAME -o jsonpath='{.status.podIP}'`
-    echo "Current master is $MASTER_IP"
-    echo "Self IP is $SELF_IP"
+    retry=1
+    for i in {0..2}
+    do
+      MASTER_IP=`/k8s/kubectl --namespace {{ .Release.Namespace }} get pod -o jsonpath='{range .items[*]}{.metadata.name} {.status.podIP}{"\n"}{end}' -l graylog-role=master --field-selector=status.phase=Running|awk '{print $2}'`
+      SELF_IP=`/k8s/kubectl --namespace {{ .Release.Namespace }} get pod $HOSTNAME -o jsonpath='{.status.podIP}'`
+      echo "Current master is $MASTER_IP"
+      echo "Self IP is $SELF_IP"
+      retry=$((retry+1))
+      [[ ! -z "$MASTER_IP" ]] && break
+      echo "[Try ${retry}/3] Waiting for master node..."
+      sleep 2
+    done
     if [[ -z "$MASTER_IP" ]]; then
       echo "Launching $HOSTNAME as master"
       export GRAYLOG_IS_MASTER="true"

--- a/charts/graylog/templates/statefulset.yaml
+++ b/charts/graylog/templates/statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       tolerations:
 {{ toYaml .Values.graylog.tolerations | indent 8 }}
 {{- end }}
-      {{- if .Values.imagePullSecrets }}
+{{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
@@ -100,17 +100,17 @@ spec:
 {{- end }}
       containers:
         - name: graylog-server
-          image: "{{ .Values.graylog.image.repository }}"
+          image: "{{ .Values.graylog.image.repository }}:{{ .Values.graylog.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.graylog.image.pullPolicy | quote }}
           command:
             - /entrypoint.sh
           env:
             - name: GRAYLOG_SERVER_JAVA_OPTS
-              {{- $javaOpts := "-Djava.net.preferIPv4Stack=true -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow" }}
+              {{- $javaOpts := .Values.graylog.javaOpts }}
               {{- if .Values.graylog.heapSize }}
-              value: "{{ $javaOpts }} {{ printf "-Xms%s -Xmx%s" .Values.graylog.heapSize .Values.graylog.heapSize}} {{ .Values.graylog.additionalJavaOpts }}"
+              value: "{{ $javaOpts }} {{ printf "-Xms%s -Xmx%s" .Values.graylog.heapSize .Values.graylog.heapSize}}"
               {{- else }}
-              value: "{{ $javaOpts }} -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap {{ .Values.graylog.additionalJavaOpts }}"
+              value: "{{ $javaOpts }} -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
               {{- end }}
             - name: GRAYLOG_PASSWORD_SECRET
               valueFrom:
@@ -214,6 +214,8 @@ spec:
           {{- if .Values.graylog.extraVolumeMounts }}
           {{ toYaml .Values.graylog.extraVolumeMounts | nindent 12 }}
           {{- end }}
+          {{ $graylogVersion := .Values.graylog.image.tag | default .Chart.AppVersion }}
+          {{- if semverCompare "< 4.2.0-0" ( $graylogVersion ) }}
           lifecycle:
             preStop:
               exec:
@@ -221,10 +223,12 @@ spec:
                   - bash
                   - -ec
                   - |
+                    ROOT_PASSWORD=`/k8s/kubectl get secret {{ template "graylog.fullname" . }} -o "jsonpath={.data['graylog-password-secret']}" | base64 -d`
                     curl {{ if .Values.graylog.tls.enabled }}-k{{ end }} -XPOST -sS \
-                      -u "{{ .Values.graylog.rootUsername }}:${GRAYLOG_PASSWORD_SECRET}" \
+                      -u "{{ .Values.graylog.rootUsername }}:${ROOT_PASSWORD}" \
                       -H "X-Requested-By: {{ template "graylog.fullname" . }}" \
                       {{ template "graylog.formatUrl" (list . "localhost:9000/api/system/shutdown/shutdown") }}
+          {{- end }}
       {{- if .Values.graylog.sidecarContainers }}
         {{ toYaml .Values.graylog.sidecarContainers | nindent 8 }}
       {{- end }}

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -54,8 +54,12 @@ graylog:
   ## Make sure you strict with the `x` version of Graylog where `x` is ${version}-${x}
   ##
   image:
-    repository: "graylog/graylog:4.1.3-1"
+    repository: "graylog/graylog"
+    tag: "4.2.3-1"
     pullPolicy: "IfNotPresent"
+
+  ## Graylog default Java option
+  javaOpts: "-Dlog4j2.formatMsgNoLookups=true -Djdk.tls.acknowledgeCloseNotify=true -XX:+UnlockExperimentalVMOptions -XX:NewRatio=1 -XX:MaxMetaspaceSize=256m -server -XX:+ResizeTLAB -XX:-OmitStackTraceInFastThrow"
 
   ## Number of Graylog instance
   ##
@@ -309,6 +313,7 @@ graylog:
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   ##
   updateStrategy: RollingUpdate
+
   ## Graylog server pod termination grace period
   ##
   terminationGracePeriodSeconds: 120
@@ -494,9 +499,10 @@ elasticsearch:
     replicas: 1
   cluster:
     env:
-      MINIMUM_MASTER_NODES: 1
+      MINIMUM_MASTER_NODES: "1"
     xpackEnable: false
 
+# Specify Mongodb settings. Ignore this section if you install MongoDB manually.
 mongodb:
   architecture: "replicaset"
   useStatefulSet: true


### PR DESCRIPTION
# What this PR does / why we need it

* Update default Graylog image to 4.2.3 #85 #84
* Remove `additionalJavaOpts` in favor of `javaOpts`
* Split image tag to a new field
* Add limit retry when finding master node  #44
* Remove `system/shutdown/shutdown` API when Graylog version 4.2.x https://github.com/Graylog2/graylog2-server/issues/11129

# Which issue this PR fixes

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/KongZ/charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
