### PR TITLE
Remove scheme prefix from helpers for graylog.elasticsearch.hosts.

### DIFF
--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 2.0.0
+version: 2.0.1
 appVersion: 4.2.3
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:

--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -91,11 +91,7 @@ Or use chart dependencies with release name
 */}}
 {{- define "graylog.elasticsearch.hosts" -}}
 {{- if .Values.graylog.elasticsearch.uriSecretKey }}
-    {{- if .Values.graylog.elasticsearch.uriSSL }}
-        {{- printf "https://${GRAYLOG_ELASTICSEARCH_HOSTS}" -}}
-    {{- else }}
-        {{- printf "http://${GRAYLOG_ELASTICSEARCH_HOSTS}" -}}
-    {{- end }}
+    {{- printf "${GRAYLOG_ELASTICSEARCH_HOSTS}" -}}
 {{- else if .Values.graylog.elasticsearch.hosts }}
     {{- .Values.graylog.elasticsearch.hosts -}}
 {{- else }}


### PR DESCRIPTION
# What this PR does / why we need it
This PR fixes a regression introduced by the use of the variable name `GRAYLOG_ELASTICSEARCH_HOSTS` introduced in PR #101.

# Which issue this PR fixes
- fixes #104 

# Special notes for your reviewer
I wasn't sure whether to try to append the scheme or remove the conditional. However, I chose to align with the values.yaml documentation below, where the scheme is included in the input as opposed to added by the chart. I 
think trying to handle it elsewhere will end up doing string replacements, which would get messy.

https://github.com/KongZ/charts/blob/main/charts/graylog/values.yaml#L367
```yaml
graylog:
  # ...
  elasticsearch:
    # ...
    # hosts: http://elasticsearch-client.graylog.svc.cluster.local:9200
    hosts: ""
```

# Checklist
- [x] [DCO](https://github.com/KongZ/charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped

@KongZ 