### PR TITLE
Use graylog.externalUri to provide GRAYLOG_HTTP_PUBLISH_URI env variable to the main container

### DIFF
--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 2.0.0
+version: 2.1.0
 appVersion: 4.2.3
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:

--- a/charts/graylog/templates/statefulset.yaml
+++ b/charts/graylog/templates/statefulset.yaml
@@ -108,6 +108,11 @@ spec:
               {{- else }}
               value: "{{ $javaOpts }} -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
               {{- end }}
+            {{- $externalUri := include "graylog.url" . }}
+            {{- if $externalUri }}
+            - name: GRAYLOG_HTTP_PUBLISH_URI
+              value: "{{ $externalUri }}"
+            {{- end }}
             - name: GRAYLOG_PASSWORD_SECRET
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Use `graylog.externalUri` from values.yaml to configure the environment variable `GRAYLOG_HTTP_PUBLISH_URI` in the graylog server container.

This value is apparently necessary for the Graylog Docker image used here. The default deployment stopped working when the environment variable was removed from the entrypoint in the last chart update (https://github.com/KongZ/charts/commit/4eea0627a026586d496b81babb79d08bea2ef534#r67339863)

Fix https://github.com/KongZ/charts/issues/107.

Signed-off-by: Julio Morimoto <julio@morimoto.net.br>