### PR TITLE
Set default es version to 7.10.2

### DIFF
--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 2.1.1
+version: 2.1.2
 appVersion: 4.2.7
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:
@@ -17,7 +17,7 @@ maintainers:
     email: goonohc@gmail.com
 dependencies:
   - name: elasticsearch
-    version: 7.16.2
+    version: 7.10.2
     repository: https://helm.elastic.co
     tags:
       - install-elasticsearch


### PR DESCRIPTION
# What this PR does / why we need it
Graylog does not officially support Elasticsearch version newer than 7.10.2. See https://docs.graylog.org/v1/docs/elasticsearch

# Which issue this PR fixes

- fixes #113 

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/KongZ/charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
