### PR TITLE
Support supplying probes with custom paths and ports in case of a more custom setup

### DIFF
--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 2.1.2
+version: 2.1.3
 appVersion: 4.2.7
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:

--- a/charts/graylog/templates/statefulset.yaml
+++ b/charts/graylog/templates/statefulset.yaml
@@ -171,8 +171,8 @@ spec:
 {{ toYaml .Values.graylog.resources | indent 12 }}
           startupProbe:
             httpGet:
-              path: /api/system/lbstatus
-              port: 9000
+              path: {{ .Values.graylog.startupProbe.path }}
+              port: {{ .Values.graylog.startupProbe.port }}
             {{- if .Values.graylog.tls.enabled }}
               scheme: HTTPS
             {{- end }}
@@ -182,8 +182,8 @@ spec:
             timeoutSeconds: {{ .Values.graylog.startupProbe.timeoutSeconds }}
           livenessProbe:
             httpGet:
-              path: /api/system/lbstatus
-              port: 9000
+              path: {{ .Values.graylog.livenessProbe.path }}
+              port: {{ .Values.graylog.livenessProbe.port }}
             {{- if .Values.graylog.tls.enabled }}
               scheme: HTTPS
             {{- end }}
@@ -194,8 +194,8 @@ spec:
             timeoutSeconds: {{ .Values.graylog.livenessProbe.timeoutSeconds }}
           readinessProbe:
             httpGet:
-              path: /api/system/lbstatus
-              port: 9000
+              path: {{ .Values.graylog.readinessProbe.path }}
+              port: {{ .Values.graylog.readinessProbe.port }}
             {{- if .Values.graylog.tls.enabled }}
               scheme: HTTPS
             {{- end }}

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -214,12 +214,16 @@ graylog:
       type: ClusterIP
 
   startupProbe:
+    path: /api/system/lbstatus
+    port: 9000
     periodSeconds: 60
     failureThreshold: 3
     successThreshold: 1
     timeoutSeconds: 5
 
   livenessProbe:
+    path: /api/system/lbstatus
+    port: 9000
     initialDelaySeconds: 0
     periodSeconds: 30
     failureThreshold: 3
@@ -227,6 +231,8 @@ graylog:
     timeoutSeconds: 5
 
   readinessProbe:
+    path: /api/system/lbstatus
+    port: 9000
     initialDelaySeconds: 0
     periodSeconds: 10
     failureThreshold: 3


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/KongZ/charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->

# What this PR does / why we need it

This PR supports further customization of startupProbe, livenessProbe and readinessProbe to take into account any custom paths and/or ports that might be in use instead of the defaults

# Which issue this PR fixes

-

# Special notes for your reviewer

-

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/KongZ/charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
