### PR TITLE
Add metrics port

### DIFF
--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 2.1.4
+version: 2.1.5
 appVersion: 4.2.7
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:

--- a/charts/graylog/templates/headless-service.yaml
+++ b/charts/graylog/templates/headless-service.yaml
@@ -13,6 +13,7 @@ spec:
 {{- if .Values.graylog.metrics.enabled }}
     - name: metrics
       port: 9833
+      targetPort: 9833
 {{- end }}
   type: ClusterIP
   clusterIP: None

--- a/charts/graylog/templates/headless-service.yaml
+++ b/charts/graylog/templates/headless-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "graylog.metrics.enabled" . }}
+  name: {{ template "graylog.service.headless.name" . }}
   labels:
 {{ include "graylog.metadataLabels" . | indent 4 }}
   annotations:

--- a/charts/graylog/templates/headless-service.yaml
+++ b/charts/graylog/templates/headless-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "graylog.service.headless.name" . }}
+  name: {{ template "graylog.metrics.enabled" . }}
   labels:
 {{ include "graylog.metadataLabels" . | indent 4 }}
   annotations:
@@ -10,6 +10,10 @@ spec:
   ports:
     - name: graylog
       port: 9000
+{{- if .Values.graylog.metrics.enabled }}
+    - name: metrics
+      port: 9833
+{{- end }}
   type: ClusterIP
   clusterIP: None
   publishNotReadyAddresses: true

--- a/charts/graylog/templates/servicemonitor.yaml
+++ b/charts/graylog/templates/servicemonitor.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-    - port: 9833
+    - port: metrics
       path: /metrics
       {{- if .Values.graylog.metrics.serviceMonitor.interval }}
       interval: {{ .Values.graylog.metrics.serviceMonitor.interval }}

--- a/charts/graylog/templates/servicemonitor.yaml
+++ b/charts/graylog/templates/servicemonitor.yaml
@@ -24,6 +24,5 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      app: {{ template "graylog.fullname" . }}
-      release: {{ .Release.Name }}
+{{ include "graylog.selectorLabels" . | indent 6 }}
 {{- end }}

--- a/charts/graylog/templates/statefulset.yaml
+++ b/charts/graylog/templates/statefulset.yaml
@@ -146,6 +146,10 @@ spec:
           ports:
             - containerPort: 9000
               name: graylog
+          {{- if .Values.graylog.metrics.enabled }}
+            - containerPort: 9833
+              name: metrics
+          {{- end }}
           {{- range .Values.graylog.service.ports }}
             - containerPort: {{ .port }}
               name: {{ .name}}


### PR DESCRIPTION
This PR fixes problems with the way servicemonitor wants to match endpoints.
In the latest version of the CRD serviceMonitor, port can only be a string field describing the name of the endpoint port.

I added the endpoints to the pods if metrics were enabled, and updated the selection criteria to match other parts of the chart.

signed-off-by: Ken Hahn <yokhahn@gmail.com>