### PR TITLE
Upgrading to Graylog 5

### DIFF
--- a/.github/workflows/chart-testing.yaml
+++ b/.github/workflows/chart-testing.yaml
@@ -35,8 +35,8 @@ jobs:
         id: list-changed
         run: |
           changed=$(ct list-changed --target-branch main)
-          if [[ -n '$changed' ]]; then
-            echo 'changed=true' >> $GITHUB_OUTPUT
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run chart-testing (lint)

--- a/.github/workflows/chart-testing.yaml
+++ b/.github/workflows/chart-testing.yaml
@@ -36,7 +36,7 @@ jobs:
         run: |
           changed=$(ct list-changed --target-branch main)
           if [[ -n "$changed" ]]; then
-            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "::set-output name=changed::true"
           fi
 
       - name: Run chart-testing (lint)

--- a/.github/workflows/chart-testing.yaml
+++ b/.github/workflows/chart-testing.yaml
@@ -35,8 +35,8 @@ jobs:
         id: list-changed
         run: |
           changed=$(ct list-changed --target-branch main)
-          if [[ -n "$changed" ]]; then
-            echo "changed=true" >> $GITHUB_OUTPUT
+          if [[ -n '$changed' ]]; then
+            echo 'changed=true' >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)

--- a/.github/workflows/chart-testing.yaml
+++ b/.github/workflows/chart-testing.yaml
@@ -36,7 +36,7 @@ jobs:
         run: |
           changed=$(ct list-changed --target-branch main)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)

--- a/.github/workflows/chart-testing.yaml
+++ b/.github/workflows/chart-testing.yaml
@@ -20,9 +20,9 @@ jobs:
       - name: Add dependency chart repos
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm repo add elastic https://helm.elastic.co
           helm repo add stable https://charts.helm.sh/stable
           helm repo add kongz https://charts.kong-z.com
+          helm repo add opensearch https://opensearch-project.github.io/helm-charts/
 
       - uses: actions/setup-python@v2.2.2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,4 +29,4 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
         env:
-          GITHUB_TOKEN: ${{ secrets.CR_TOKEN }}
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,4 +29,4 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
         env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: ${{ secrets.CR_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,14 +7,10 @@ on:
 
 jobs:
   release:
-    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
-    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
-    permissions:
-      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
@@ -24,7 +20,9 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,6 @@ jobs:
         uses: azure/setup-helm@v3
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
+        uses: helm/chart-releaser-action@v1.2.1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,10 +7,14 @@ on:
 
 jobs:
   release:
+    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
+    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -20,11 +24,9 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: v3.4.0
+        uses: azure/setup-helm@v3
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+        uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,4 +29,5 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,6 @@ jobs:
         uses: azure/setup-helm@v3
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
+        uses: helm/chart-releaser-action@v1.2.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -13,7 +13,7 @@ keywords:
   - gelf
 icon: https://global-uploads.webflow.com/5a218ef7897bf400019e2f16/5a218ef7897bf400019e2f60_logo-graylog.png
 sources:
-  - https://github.com/KongZ/charts
+  - https://github.com/luizjr/graylog-charts
 maintainers:
   - name: KongZ
     email: goonohc@gmail.com

--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -17,7 +17,7 @@ sources:
 maintainers:
   - name: KongZ
     email: goonohc@gmail.com
-  - name: Luiz Jr
+  - name: "Luiz Jr"
     email: lj@luizjr.dev
     url: https://luizjr.dev
 dependencies:

--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -29,6 +29,6 @@ dependencies:
   - tags:
       - install-opensearch
     name: opensearch
-    version: 2.10.0
+    version: 2.0.1
     repository: https://opensearch-project.github.io/helm-charts
 type: application

--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -13,7 +13,7 @@ keywords:
   - gelf
 icon: https://global-uploads.webflow.com/5a218ef7897bf400019e2f16/5a218ef7897bf400019e2f60_logo-graylog.png
 sources:
-  - https://github.com/luizjr/graylog-charts
+  - https://github.com/KongZ/charts
 maintainers:
   - name: KongZ
     email: goonohc@gmail.com

--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: graylog
 home: https://www.graylog.org
 version: 2.3.0
-appVersion: "5.0.2"
+appVersion: 5.0.2
 description: Graylog is the centralized log management solution built to open
   standards for capturing, storing, and enabling real-time analysis of terabytes
   of machine data.
@@ -17,7 +17,7 @@ sources:
 maintainers:
   - name: KongZ
     email: goonohc@gmail.com
-  - name: "Luiz Jr"
+  - name: LuizJr
     email: lj@luizjr.dev
     url: https://luizjr.dev
 dependencies:

--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,9 +1,11 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 2.2.0
-appVersion: 4.3.8
-description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
+version: 2.3.0
+appVersion: "5.0.2"
+description: Graylog is the centralized log management solution built to open
+  standards for capturing, storing, and enabling real-time analysis of terabytes
+  of machine data.
 keywords:
   - graylog
   - logs
@@ -15,19 +17,18 @@ sources:
 maintainers:
   - name: KongZ
     email: goonohc@gmail.com
+  - name: Luiz Jr
+    email: lj@luizjr.dev
+    url: https://luizjr.dev
 dependencies:
-  - name: elasticsearch
-    version: 7.16.2
-    repository: https://helm.elastic.co
-    tags:
-      - install-elasticsearch
-  - name: mongodb
-    version: 13.6.4
-    repository: https://charts.bitnami.com/bitnami
-    tags:
+  - tags:
       - install-mongodb
-  - name: opensearch
-    version: 2.9.1
-    repository: https://opensearch-project.github.io/helm-charts
-    tags:
+    name: mongodb
+    version: 13.6.6
+    repository: https://charts.bitnami.com/bitnami
+  - tags:
       - install-opensearch
+    name: opensearch
+    version: 2.10.0
+    repository: https://opensearch-project.github.io/helm-charts
+type: application

--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -29,6 +29,6 @@ dependencies:
   - tags:
       - install-opensearch
     name: opensearch
-    version: 2.0.1
+    version: 2.8.0
     repository: https://opensearch-project.github.io/helm-charts
 type: application

--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -22,7 +22,12 @@ dependencies:
     tags:
       - install-elasticsearch
   - name: mongodb
-    version: 10.31.2
+    version: 13.6.4
     repository: https://charts.bitnami.com/bitnami
     tags:
       - install-mongodb
+  - name: opensearch
+    version: 2.9.1
+    repository: https://opensearch-project.github.io/helm-charts
+    tags:
+      - install-opensearch

--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -8,7 +8,7 @@ Note: It is strongly recommend to use on Official Graylog image to run this char
 This chart requires the following charts before install Graylog
 
 1. MongoDB
-2. Elasticsearch
+2. Opensearch
 
 To install the Graylog Chart with all dependencies
 
@@ -20,7 +20,7 @@ helm install --namespace "graylog" graylog kongz/graylog
 
 ## Manually Install Dependencies
 
-This method is *recommended* when you want to expand the availability, scalability, and security of the services. You need to install MongoDB replicaset and Elasticsearch with proper settings before install Graylog.
+This method is _recommended_ when you want to expand the availability, scalability, and security of the services. You need to install MongoDB replicaset and Opensearch with proper settings before install Graylog.
 
 To install MongoDB, run
 
@@ -30,16 +30,16 @@ helm install --namespace "graylog" mongodb bitnami/mongodb
 
 Note: There are many alternative MongoDB available on [artifacthub.io](https://artifacthub.io/packages/search?page=1&ts_query_web=mongodb). If you found the `bitnami/mongodb` is not suitable, you can use another MongoDB chart. Modify `graylog.mongodb.uri` to match your MongoDB endpoint.
 
-To install Elasticsearch, run
+To install Opensearch, run
 
 ```bash
-helm install --namespace "graylog" elasticsearch elastic/elasticsearch
+helm install --namespace "graylog" opensearch elastic/opensearch
 ```
 
-The Elasticsearch installation command above will install all Elasticsearch
-nodes types in single node. It is strongly recommend to follow the Elasticsearch [guide](https://github.com/elastic/helm-charts/tree/main/elasticsearch#how-to-deploy-dedicated-nodes-types) to install dedicated node on production.
+The Opensearch installation command above will install all Opensearch
+nodes types in single node. It is strongly recommend to follow the Opensearch [guide](https://github.com/elastic/helm-charts/tree/main/epensearch#how-to-deploy-dedicated-nodes-types) to install dedicated node on production.
 
-Note: There are many alternative Elasticsearch available on [artifacthub.io](https://artifacthub.io/packages/search?page=1&ts_query_web=elasticsearch). If you found the `stable/elasticsearch` is not suitable, you can search other charts from GitHub repositories.
+Note: There are many alternative Opensearch available on [artifacthub.io](https://artifacthub.io/packages/search?page=1&ts_query_web=Opensearch). If you found the `stable/opensearch` is not suitable, you can search other charts from GitHub repositories.
 
 ## Install Chart
 
@@ -48,10 +48,10 @@ To install the Graylog Chart into your Kubernetes cluster (This Chart requires p
 ```bash
 helm install --namespace "graylog" graylog kongz/graylog \
   --set tags.install-mongodb=false\
-  --set tags.install-elasticsearch=false\
+  --set tags.install-opensearch=false\
   --set graylog.mongodb.uri=mongodb://mongodb-mongodb-replicaset-0.mongodb-mongodb-replicaset.graylog.svc.cluster.local:27017/graylog?replicaSet=rs0 \
-  --set graylog.elasticsearch.hosts=http://elasticsearch-master.graylog.svc.cluster.local:9200
-  --set graylog.elasticsearch.version=7
+  --set graylog.opensearch.hosts=http://opensearch-cluster-master.graylog.svc.cluster.local:9200
+  --set graylog.opensearch.version=7
 ```
 
 After installation succeeds, you can get a status of Chart
@@ -90,7 +90,7 @@ Set the following values in `values.yaml`
 
 ```yaml
 graylog:
-   nodeSelector: { cloud.google.com/gke-nodepool: graylog-pool }
+  nodeSelector: { cloud.google.com/gke-nodepool: graylog-pool }
 ```
 
 ### Using tolerations
@@ -110,129 +110,127 @@ graylog:
 
 The following table lists the configurable parameters of the Graylog chart and their default values.
 
-| Parameter                                      | Description                                                                                                                                           | Default                           |
-|------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------|
-| `graylog.image.repository`                     | `graylog` image repository                                                                                                                            | `graylog/graylog`                 |
-| `graylog.image.tag`                            | `graylog` image tag                                                                                                                                   | `4.2.7-1`                         |
-| `graylog.image.pullPolicy`                     | Image pull policy                                                                                                                                     | `IfNotPresent`                    |
-| `graylog.replicas`                             | The number of Graylog instances in the cluster. The chart will automatic create assign master to one of replicas                                      | `2`                               |
-| `graylog.resources`                            | CPU/Memory resource requests/limits                                                                                                                   | Memory: `1024Mi`, CPU: `500m`     |
-| `graylog.heapSize`                             | Override Java heap size. If this value empty, chart will allocate heap size using `-XX:+UseCGroupMemoryLimitForHeap`                                  |                                   |
-| `graylog.externalUri`                          | External URI that Graylog is available at                                                                                                             |                                   |
-| `graylog.nodeSelector`                         | Graylog server pod assignment                                                                                                                         | `{}`                              |
-| `graylog.affinity`                             | Graylog server affinity                                                                                                                               | `{}`                              |
-| `graylog.tolerations`                          | Graylog server tolerations                                                                                                                            | `[]`                              |
-| `graylog.nodeSelector`                         | Graylog server node selector                                                                                                                          | `{}`                              |
-| `graylog.env`                                  | Graylog server env variables                                                                                                                          | `{}`                              |
-| `graylog.customLabels`                         | Graylog additional labels for statefulset/pods                                                                                                        | `{}`                              |
-| `graylog.envRaw`                               | Graylog server env variables in raw yaml format                                                                                                       | `{}`                              |
-| `graylog.podSecurityContext`                   | Set security context for defining privilege and accessing control settings entire Pod                                                                 | `{}`                              |
-| `graylog.securityContext`                      | Set security context for defining privilege and accessing control settings for Graylog container                                                      | `privileged: false`               |
-| `graylog.javaOpts`                             | Graylog service `JAVA_OPTS`                                                                                                                           |                                   |
-| ~~graylog.additionalJavaOpts~~                 | Graylog service additional `JAVA_OPTS` (Replaced with `graylog.javaOpts`)                                                                             |                                   |
-| `graylog.service.type`                         | Kubernetes Service type                                                                                                                               | `ClusterIP`                       |
-| `graylog.service.port`                         | Graylog Service port                                                                                                                                  | `9000`                            |
-| `graylog.service.ports`                        | Graylog Service extra ports                                                                                                                           | `[]`                              |
-| `graylog.service.master.enabled`               | If true, Graylog Master Service will be created                                                                                                       | `true`                            |
-| `graylog.service.master.port`                  | Graylog Master Service port                                                                                                                           | `9000`                            |
-| `graylog.service.master.type`                  | Graylog Master Service type                                                                                                                           | `ClusterIP`                       |
-| `graylog.service.master.annotations`           | Graylog Master Service annotations                                                                                                                    | `{}`                              |
-| `graylog.service.headless.suffix`              | If present, suffix appended to the name of the chart to form the headless service name, ie: `-headless` would result in `graylog-headless`            |                                   |
-| `graylog.podAnnotations`                       | Kubernetes Pod annotations                                                                                                                            | `{}`                              |
-| `graylog.priorityClassName`                    | If specified, indicates the pod's priority.                                                                                                           | ``                                |
-| `graylog.terminationGracePeriodSeconds`        | Pod termination grace period                                                                                                                          | `120`                             |
-| `graylog.updateStrategy`                       | Update Strategy of the StatefulSet                                                                                                                    | `RollingUpdate`                   |
-| `graylog.persistence.enabled`                  | Use a PVC to persist data                                                                                                                             | `true`                            |
-| `graylog.persistence.storageClass`             | Storage class of backing PVC (uses storage class annotation)                                                                                          | `nil`                             |
-| `graylog.persistence.accessMode`               | Use volume as ReadOnly or ReadWrite                                                                                                                   | `ReadWriteOnce`                   |
-| `graylog.persistence.size`                     | Size of data volume                                                                                                                                   | `10Gi`                            |
-| `graylog.tls.enabled`                          | If true, Graylog will listen on HTTPS                                                                                                                 | `false`                           |
-| `graylog.tls.keyFile`                          | Path to key file for HTTPS                                                                                                                            | `/etc/graylog/server/server.key`  |
-| `graylog.tls.certFile`                         | Path to crt file for HTTPS                                                                                                                            | `/etc/graylog/server/server.cert` |
-| `graylog.ingress.enabled`                      | If true, Graylog Ingress will be created                                                                                                              | `false`                           |
-| `graylog.ingress.ingressClassName`             | Graylog Ingress class name                                                                                                                            |                                   |
-| `graylog.ingress.port`                         | Graylog Ingress port                                                                                                                                  | `false`                           |
-| `graylog.ingress.annotations`                  | Graylog Ingress annotations                                                                                                                           | `{}`                              |
-| `graylog.ingress.hosts`                        | Graylog Ingress host names                                                                                                                            | `[]`                              |
-| `graylog.ingress.tls`                          | Graylog Ingress TLS configuration (YAML)                                                                                                              | `[]`                              |
-| `graylog.ingress.pathType`                     | Graylog Ingress path type                                                                                                                             | `Prefix`                          |
-| `graylog.ingress.extraPaths`                   | Ingress extra paths to prepend to every host configuration. Useful when configuring [custom actions with AWS ALB Ingress Controller][2].              | `[]`                              |
-| `graylog.input`                                | Graylog Input configuration (YAML) Sees #Input section for detail                                                                                     | `{}`                              |
-| `graylog.input.tcp.service.name`               | Graylog TCP Input service name                                                                                                                        | `graylog-tcp`                     |
-| `graylog.input.udp.service.name`               | Graylog UDP Input service name                                                                                                                        | `graylog-udp`                     |
-| `graylog.metrics.enabled`                      | If true, add Prometheus annotations to pods                                                                                                           | `false`                           |
-| `graylog.metrics.serviceMonitor.enabled`       | If true, a ServiceMonitor resource for the prometheus-operator is created                                                                             | `false`                           |
-| `graylog.metrics.serviceMonitor.additionalLabels` | ServiceMonitor additional Labels                                                                                                                   | `false`                           |
-| `graylog.metrics.serviceMonitor.scrapeTimeout` | ServiceMonitor Timeout for scraping                                                                                                                   | `false`                           |
-| `graylog.metrics.serviceMonitor.interval`      | ServiceMonitor Interval at which Prometheus scrapes metrics                                                                                           | `false`                           |
-| `graylog.geoip.enabled`                        | If true, Maxmind Geoip Lite will be installed to ${GRAYLOG_HOME}/etc/GeoLite2-City.mmdb                                                               | `false`                           |
-| `graylog.geoip.mmdbUri`                        | If set and geoip enabled,  Maxmind Geoip Lite will be installed from the URL you have defined to ${GRAYLOG_HOME}/etc/GeoLite2-City.mmdb               |                                   |
-| `graylog.plugins.locations`                    | A list of Graylog installation plugins                                                                                                                | `[]`                              |
-| `graylog.plugins.proxy.enabled`                | If true, configure a proxy server to download the plugins                                                                                             | `false`                           |
-| `graylog.plugins.proxy.host`                   | The proxy server that should be used to download the plugins                                                                                          | `http://your.proxy.host:8080`     |
-| `graylog.rootUsername`                         | Graylog root user name                                                                                                                                | `admin`                           |
-| `graylog.rootPassword`                         | Graylog root password. If not set, random 16-character alphanumeric string                                                                            |                                   |
-| `graylog.rootEmail`                            | Graylog root email.                                                                                                                                   |                                   |
-| `graylog.existingRootSecret`                   | Graylog existing root secret                                                                                                                          |                                   |
-| `graylog.rootTimezone`                         | Graylog root timezone.                                                                                                                                | `UTC`                             |
-| `graylog.elasticsearch.version`                | Graylog Elasticsearch version. You need to specify a value 6 or 7. It is required for Graylog >4.0.2                                                  | `6`                               |
-| `graylog.elasticsearch.hosts`                  | Graylog Elasticsearch host name. You need to specific where data will be stored.                                                                      |                                   |
-| `graylog.elasticsearch.uriSecretName`          | K8s secret name where elasticsearch hosts will be set from.                                                                                           | `{{ graylog.fullname }}-es`       |
-| `graylog.elasticsearch.uriSecretKey`           | K8s secret key name where elasticsearch hosts will be set from.                                                                                       |                                   |
-| `graylog.elasticsearch.uriSSL`                 | Prepends 'https://' to the URL fetched from 'uriSecretKey' if true. Prepends `http://` otherwise.                                                     | `false`                           |
-| `graylog.mongodb.uri`                          | Graylog MongoDB connection string. You need to specific where data will be stored.                                                                    |                                   |
-| `graylog.mongodb.uriSecretName`                | K8s secret name where MongoDB URI will be set from.                                                                                                   | `{{ graylog.fullname }}-mongodb`  |
-| `graylog.mongodb.uriSecretKey`                 | K8s secret key name where MongoDB URI will be set from.                                                                                               |                                   |
-| `graylog.transportEmail.enabled`               | If true, enable transport email settings on Graylog                                                                                                   | `false`                           |
-| `graylog.transportEmail.hostname`              | The hostname of the server used to send the email                                                                                                     |                                   |
-| `graylog.transportEmail.port`                  | The port of the server used to send the email                                                                                                         |                                   |
-| `graylog.transportEmail.useTls`                | If true, use TLS to connect to the mailserver                                                                                                         |                                   |
-| `graylog.transportEmail.useSsl`                | If true, use SSL to connect to the mailserver                                                                                                         |                                   |
-| `graylog.transportEmail.useAuth`               | If true, authenticate to the email server                                                                                                             |                                   |
-| `graylog.transportEmail.authUsername`          | The username for server authentication                                                                                                                |                                   |
-| `graylog.transportEmail.authPassword`          | The password for server authentication                                                                                                                |                                   |
-| `graylog.transportEmail.subjectPrefix`         | Prepend this string to every mail subjects                                                                                                            |                                   |
-| `graylog.transportEmail.fromEmail`             | Use this as a FROM address                                                                                                                            |                                   |
-| `graylog.config`                               | Add additional server configuration to `graylog.conf` file.                                                                                           |                                   |
-| `graylog.serverFiles`                          | Add additional server files on /etc/graylog/server. This is useful for enable TLS on input                                                            | `{}`                              |
-| `graylog.logInJson`                            | If true, Graylog pods will be configured to log in JSON (one event per line                                                                           | `false`                           |
-| `graylog.journal.deleteBeforeStart`            | Delete all journal files before start Graylog                                                                                                         | `false`                           |
-| `graylog.journal.maxSize`                      | Maximum size of message_journal_max_size in Graylog Config                                                                                            | `5gb`                             |
-| `graylog.init.image.repository`                | Configure init container image                                                                                                                        | `busybox`                         |
-| `graylog.init.image.pullPolicy`                | Configure init container image pull policy                                                                                                            | `{}`                              |
-| `graylog.init.kubectlLocation`                 | Set kubectl location to download and use on init-container.                                                                                           |                                   |
-| `graylog.init.kubectlVersion`                  | Set kubectl command version to download. If the value is not set, default value is .Capabilities.KubeVersion.Version                                  |                                   |
-| `graylog.init.env`                             | Additional environment variables to be added to Graylog initContainer                                                                                 | `{}`                              |
-| `graylog.init.resources`                       | Configure resource requests and limits for the Graylog StatefulSet initContainer                                                                      | `{}`                              |
-| `graylog.provisioner.enabled`                  | Enable optional Job to run an arbitrary Bash script                                                                                                   | `false`                           |
-| `graylog.provisioner.env`                      | Job environment variables                                                                                                                             | `false`                           |
-| `graylog.provisioner.envRaw`                   | Job environment variables in raw yaml format                                                                                                          | `false`                           |
-| `graylog.provisioner.annotations`              | Graylog provisioner Job annotations                                                                                                                   | `{}`                              |
-| `graylog.provisioner.useGraylogServiceAccount` | Use the same ServiceAccount used by Graylog pod                                                                                                       | `false`                           |
-| `graylog.provisioner.script`                   | The contents of the provisioner Bash script                                                                                                           |                                   |
-| `graylog.sidecarContainers`                    | Sidecar containers to run in the server statefulset                                                                                                   | `[]`                              |
-| `graylog.extraVolumeMounts`                    | Additional Volume mounts                                                                                                                              | `[]`                              |
-| `graylog.extraVolumes`                         | Additional Volumes                                                                                                                                    | `[]`                              |
-| `graylog.extraInitContainers`                  | Additional Init containers                                                                                                                            | `[]`                              |
-| `graylog.secret.annotations`                   | Graylog Secret annotations                                                                                                                            | `{}`                              |
-| `rbac.create`                                  | If true, create & use RBAC resources                                                                                                                  | `true`                            |
-| `rbac.resources`                               | List of resources                                                                                                                                     | `[pods, secrets]`                 |
-| `serviceAccount.create`                        | If true, create the Graylog service account                                                                                                           | `true`                            |
-| `serviceAccount.name`                          | Name of the server service account to use or create                                                                                                   | `{{ graylog.fullname }}`          |
-| `serviceAccount.annotations`                   | Service Account annotations                                                                                                                           | `{}`                              |
-| `tags.install-mongodb`                         | If true, this chart will install MongoDB from requirement dependencies. If you want to install MongoDB by yourself, please set to `false`             | `true`                            |
-| `tags.install-elasticsearch`                   | If true, this chart will install Elasticsearch from requirement dependencies. If you want to install Elasticsearch by yourself, please set to `false` | `true`                            |
-| `imagePullSecrets`                             | Configuration for [imagePullSecrets][3] so that you can use a private registry for your images                                                        | `[]`                              |
-| `graylog.options.allowHighlighting`            | If true, enable [search result highlighting][6].                                                                                                      | `false`                           |
-| `graylog.options.allowLeadingWildcardSearches` | if true, allow searches with leading wildcards. This can be extremely resource hungry and should only be enabled with care.                           | `false`                           |
-| `graylog.options.gc_warning_threshold`         | The threshold of the garbage collection runs                                                                                                          | `1s`                              |
-| `graylog.options.ringSize`                    | Size of internal ring buffers.       |          `65536`                    |
-| `graylog.options.processbufferProcessors`     | Number of processors assigned to the process buffer                                                                                                    | `5`                               |
-| `graylog.options.inputbufferProcessors`       | Number of processors assigned to the input buffer                                                                                                      | `2`                               |
-| `graylog.options.outputbufferProcessors`      | Number of processors assigned to the output buffer                                                                                                     | `3`                               |
-| `graylog.options.inputBufferRingSize`         | Size of input internal ring buffers. |          `65536`                    |
-
-
+| Parameter                                         | Description                                                                                                                                     | Default                           |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `graylog.image.repository`                        | `graylog` image repository                                                                                                                      | `graylog/graylog`                 |
+| `graylog.image.tag`                               | `graylog` image tag                                                                                                                             | `4.2.7-1`                         |
+| `graylog.image.pullPolicy`                        | Image pull policy                                                                                                                               | `IfNotPresent`                    |
+| `graylog.replicas`                                | The number of Graylog instances in the cluster. The chart will automatic create assign master to one of replicas                                | `2`                               |
+| `graylog.resources`                               | CPU/Memory resource requests/limits                                                                                                             | Memory: `1024Mi`, CPU: `500m`     |
+| `graylog.heapSize`                                | Override Java heap size. If this value empty, chart will allocate heap size using `-XX:+UseCGroupMemoryLimitForHeap`                            |                                   |
+| `graylog.externalUri`                             | External URI that Graylog is available at                                                                                                       |                                   |
+| `graylog.nodeSelector`                            | Graylog server pod assignment                                                                                                                   | `{}`                              |
+| `graylog.affinity`                                | Graylog server affinity                                                                                                                         | `{}`                              |
+| `graylog.tolerations`                             | Graylog server tolerations                                                                                                                      | `[]`                              |
+| `graylog.nodeSelector`                            | Graylog server node selector                                                                                                                    | `{}`                              |
+| `graylog.env`                                     | Graylog server env variables                                                                                                                    | `{}`                              |
+| `graylog.customLabels`                            | Graylog additional labels for statefulset/pods                                                                                                  | `{}`                              |
+| `graylog.envRaw`                                  | Graylog server env variables in raw yaml format                                                                                                 | `{}`                              |
+| `graylog.podSecurityContext`                      | Set security context for defining privilege and accessing control settings entire Pod                                                           | `{}`                              |
+| `graylog.securityContext`                         | Set security context for defining privilege and accessing control settings for Graylog container                                                | `privileged: false`               |
+| `graylog.javaOpts`                                | Graylog service `JAVA_OPTS`                                                                                                                     |                                   |
+| ~~graylog.additionalJavaOpts~~                    | Graylog service additional `JAVA_OPTS` (Replaced with `graylog.javaOpts`)                                                                       |                                   |
+| `graylog.service.type`                            | Kubernetes Service type                                                                                                                         | `ClusterIP`                       |
+| `graylog.service.port`                            | Graylog Service port                                                                                                                            | `9000`                            |
+| `graylog.service.ports`                           | Graylog Service extra ports                                                                                                                     | `[]`                              |
+| `graylog.service.master.enabled`                  | If true, Graylog Master Service will be created                                                                                                 | `true`                            |
+| `graylog.service.master.port`                     | Graylog Master Service port                                                                                                                     | `9000`                            |
+| `graylog.service.master.type`                     | Graylog Master Service type                                                                                                                     | `ClusterIP`                       |
+| `graylog.service.master.annotations`              | Graylog Master Service annotations                                                                                                              | `{}`                              |
+| `graylog.service.headless.suffix`                 | If present, suffix appended to the name of the chart to form the headless service name, ie: `-headless` would result in `graylog-headless`      |                                   |
+| `graylog.podAnnotations`                          | Kubernetes Pod annotations                                                                                                                      | `{}`                              |
+| `graylog.priorityClassName`                       | If specified, indicates the pod's priority.                                                                                                     | ``                                |
+| `graylog.terminationGracePeriodSeconds`           | Pod termination grace period                                                                                                                    | `120`                             |
+| `graylog.updateStrategy`                          | Update Strategy of the StatefulSet                                                                                                              | `RollingUpdate`                   |
+| `graylog.persistence.enabled`                     | Use a PVC to persist data                                                                                                                       | `true`                            |
+| `graylog.persistence.storageClass`                | Storage class of backing PVC (uses storage class annotation)                                                                                    | `nil`                             |
+| `graylog.persistence.accessMode`                  | Use volume as ReadOnly or ReadWrite                                                                                                             | `ReadWriteOnce`                   |
+| `graylog.persistence.size`                        | Size of data volume                                                                                                                             | `10Gi`                            |
+| `graylog.tls.enabled`                             | If true, Graylog will listen on HTTPS                                                                                                           | `false`                           |
+| `graylog.tls.keyFile`                             | Path to key file for HTTPS                                                                                                                      | `/etc/graylog/server/server.key`  |
+| `graylog.tls.certFile`                            | Path to crt file for HTTPS                                                                                                                      | `/etc/graylog/server/server.cert` |
+| `graylog.ingress.enabled`                         | If true, Graylog Ingress will be created                                                                                                        | `false`                           |
+| `graylog.ingress.ingressClassName`                | Graylog Ingress class name                                                                                                                      |                                   |
+| `graylog.ingress.port`                            | Graylog Ingress port                                                                                                                            | `false`                           |
+| `graylog.ingress.annotations`                     | Graylog Ingress annotations                                                                                                                     | `{}`                              |
+| `graylog.ingress.hosts`                           | Graylog Ingress host names                                                                                                                      | `[]`                              |
+| `graylog.ingress.tls`                             | Graylog Ingress TLS configuration (YAML)                                                                                                        | `[]`                              |
+| `graylog.ingress.pathType`                        | Graylog Ingress path type                                                                                                                       | `Prefix`                          |
+| `graylog.ingress.extraPaths`                      | Ingress extra paths to prepend to every host configuration. Useful when configuring [custom actions with AWS ALB Ingress Controller][2].        | `[]`                              |
+| `graylog.input`                                   | Graylog Input configuration (YAML) Sees #Input section for detail                                                                               | `{}`                              |
+| `graylog.input.tcp.service.name`                  | Graylog TCP Input service name                                                                                                                  | `graylog-tcp`                     |
+| `graylog.input.udp.service.name`                  | Graylog UDP Input service name                                                                                                                  | `graylog-udp`                     |
+| `graylog.metrics.enabled`                         | If true, add Prometheus annotations to pods                                                                                                     | `false`                           |
+| `graylog.metrics.serviceMonitor.enabled`          | If true, a ServiceMonitor resource for the prometheus-operator is created                                                                       | `false`                           |
+| `graylog.metrics.serviceMonitor.additionalLabels` | ServiceMonitor additional Labels                                                                                                                | `false`                           |
+| `graylog.metrics.serviceMonitor.scrapeTimeout`    | ServiceMonitor Timeout for scraping                                                                                                             | `false`                           |
+| `graylog.metrics.serviceMonitor.interval`         | ServiceMonitor Interval at which Prometheus scrapes metrics                                                                                     | `false`                           |
+| `graylog.geoip.enabled`                           | If true, Maxmind Geoip Lite will be installed to ${GRAYLOG_HOME}/etc/GeoLite2-City.mmdb                                                         | `false`                           |
+| `graylog.geoip.mmdbUri`                           | If set and geoip enabled, Maxmind Geoip Lite will be installed from the URL you have defined to ${GRAYLOG_HOME}/etc/GeoLite2-City.mmdb          |                                   |
+| `graylog.plugins.locations`                       | A list of Graylog installation plugins                                                                                                          | `[]`                              |
+| `graylog.plugins.proxy.enabled`                   | If true, configure a proxy server to download the plugins                                                                                       | `false`                           |
+| `graylog.plugins.proxy.host`                      | The proxy server that should be used to download the plugins                                                                                    | `http://your.proxy.host:8080`     |
+| `graylog.rootUsername`                            | Graylog root user name                                                                                                                          | `admin`                           |
+| `graylog.rootPassword`                            | Graylog root password. If not set, random 16-character alphanumeric string                                                                      |                                   |
+| `graylog.rootEmail`                               | Graylog root email.                                                                                                                             |                                   |
+| `graylog.existingRootSecret`                      | Graylog existing root secret                                                                                                                    |                                   |
+| `graylog.rootTimezone`                            | Graylog root timezone.                                                                                                                          | `UTC`                             |
+| `graylog.opensearch.version`                      | Graylog opensearch version. You need to specify a value 6 or 7. It is required for Graylog >4.0.2                                               | `6`                               |
+| `graylog.opensearch.hosts`                        | Graylog opensearch host name. You need to specific where data will be stored.                                                                   |                                   |
+| `graylog.opensearch.uriSecretName`                | K8s secret name where opensearch hosts will be set from.                                                                                        | `{{ graylog.fullname }}-es`       |
+| `graylog.opensearch.uriSecretKey`                 | K8s secret key name where opensearch hosts will be set from.                                                                                    |                                   |
+| `graylog.opensearch.uriSSL`                       | Prepends 'https://' to the URL fetched from 'uriSecretKey' if true. Prepends `http://` otherwise.                                               | `false`                           |
+| `graylog.mongodb.uri`                             | Graylog MongoDB connection string. You need to specific where data will be stored.                                                              |                                   |
+| `graylog.mongodb.uriSecretName`                   | K8s secret name where MongoDB URI will be set from.                                                                                             | `{{ graylog.fullname }}-mongodb`  |
+| `graylog.mongodb.uriSecretKey`                    | K8s secret key name where MongoDB URI will be set from.                                                                                         |                                   |
+| `graylog.transportEmail.enabled`                  | If true, enable transport email settings on Graylog                                                                                             | `false`                           |
+| `graylog.transportEmail.hostname`                 | The hostname of the server used to send the email                                                                                               |                                   |
+| `graylog.transportEmail.port`                     | The port of the server used to send the email                                                                                                   |                                   |
+| `graylog.transportEmail.useTls`                   | If true, use TLS to connect to the mailserver                                                                                                   |                                   |
+| `graylog.transportEmail.useSsl`                   | If true, use SSL to connect to the mailserver                                                                                                   |                                   |
+| `graylog.transportEmail.useAuth`                  | If true, authenticate to the email server                                                                                                       |                                   |
+| `graylog.transportEmail.authUsername`             | The username for server authentication                                                                                                          |                                   |
+| `graylog.transportEmail.authPassword`             | The password for server authentication                                                                                                          |                                   |
+| `graylog.transportEmail.subjectPrefix`            | Prepend this string to every mail subjects                                                                                                      |                                   |
+| `graylog.transportEmail.fromEmail`                | Use this as a FROM address                                                                                                                      |                                   |
+| `graylog.config`                                  | Add additional server configuration to `graylog.conf` file.                                                                                     |                                   |
+| `graylog.serverFiles`                             | Add additional server files on /etc/graylog/server. This is useful for enable TLS on input                                                      | `{}`                              |
+| `graylog.logInJson`                               | If true, Graylog pods will be configured to log in JSON (one event per line                                                                     | `false`                           |
+| `graylog.journal.deleteBeforeStart`               | Delete all journal files before start Graylog                                                                                                   | `false`                           |
+| `graylog.journal.maxSize`                         | Maximum size of message_journal_max_size in Graylog Config                                                                                      | `5gb`                             |
+| `graylog.init.image.repository`                   | Configure init container image                                                                                                                  | `busybox`                         |
+| `graylog.init.image.pullPolicy`                   | Configure init container image pull policy                                                                                                      | `{}`                              |
+| `graylog.init.kubectlLocation`                    | Set kubectl location to download and use on init-container.                                                                                     |                                   |
+| `graylog.init.kubectlVersion`                     | Set kubectl command version to download. If the value is not set, default value is .Capabilities.KubeVersion.Version                            |                                   |
+| `graylog.init.env`                                | Additional environment variables to be added to Graylog initContainer                                                                           | `{}`                              |
+| `graylog.init.resources`                          | Configure resource requests and limits for the Graylog StatefulSet initContainer                                                                | `{}`                              |
+| `graylog.provisioner.enabled`                     | Enable optional Job to run an arbitrary Bash script                                                                                             | `false`                           |
+| `graylog.provisioner.env`                         | Job environment variables                                                                                                                       | `false`                           |
+| `graylog.provisioner.envRaw`                      | Job environment variables in raw yaml format                                                                                                    | `false`                           |
+| `graylog.provisioner.annotations`                 | Graylog provisioner Job annotations                                                                                                             | `{}`                              |
+| `graylog.provisioner.useGraylogServiceAccount`    | Use the same ServiceAccount used by Graylog pod                                                                                                 | `false`                           |
+| `graylog.provisioner.script`                      | The contents of the provisioner Bash script                                                                                                     |                                   |
+| `graylog.sidecarContainers`                       | Sidecar containers to run in the server statefulset                                                                                             | `[]`                              |
+| `graylog.extraVolumeMounts`                       | Additional Volume mounts                                                                                                                        | `[]`                              |
+| `graylog.extraVolumes`                            | Additional Volumes                                                                                                                              | `[]`                              |
+| `graylog.extraInitContainers`                     | Additional Init containers                                                                                                                      | `[]`                              |
+| `graylog.secret.annotations`                      | Graylog Secret annotations                                                                                                                      | `{}`                              |
+| `rbac.create`                                     | If true, create & use RBAC resources                                                                                                            | `true`                            |
+| `rbac.resources`                                  | List of resources                                                                                                                               | `[pods, secrets]`                 |
+| `serviceAccount.create`                           | If true, create the Graylog service account                                                                                                     | `true`                            |
+| `serviceAccount.name`                             | Name of the server service account to use or create                                                                                             | `{{ graylog.fullname }}`          |
+| `serviceAccount.annotations`                      | Service Account annotations                                                                                                                     | `{}`                              |
+| `tags.install-mongodb`                            | If true, this chart will install MongoDB from requirement dependencies. If you want to install MongoDB by yourself, please set to `false`       | `true`                            |
+| `tags.install-opensearch`                         | If true, this chart will install opensearch from requirement dependencies. If you want to install opensearch by yourself, please set to `false` | `true`                            |
+| `imagePullSecrets`                                | Configuration for [imagePullSecrets][3] so that you can use a private registry for your images                                                  | `[]`                              |
+| `graylog.options.allowHighlighting`               | If true, enable [search result highlighting][6].                                                                                                | `false`                           |
+| `graylog.options.allowLeadingWildcardSearches`    | if true, allow searches with leading wildcards. This can be extremely resource hungry and should only be enabled with care.                     | `false`                           |
+| `graylog.options.gc_warning_threshold`            | The threshold of the garbage collection runs                                                                                                    | `1s`                              |
+| `graylog.options.ringSize`                        | Size of internal ring buffers.                                                                                                                  | `65536`                           |
+| `graylog.options.processbufferProcessors`         | Number of processors assigned to the process buffer                                                                                             | `5`                               |
+| `graylog.options.inputbufferProcessors`           | Number of processors assigned to the input buffer                                                                                               | `2`                               |
+| `graylog.options.outputbufferProcessors`          | Number of processors assigned to the output buffer                                                                                              | `3`                               |
+| `graylog.options.inputBufferRingSize`             | Size of input internal ring buffers.                                                                                                            | `65536`                           |
 
 ## How it works
 
@@ -247,36 +245,36 @@ You can enable input ports by edit the `input` values. For example, you want to 
 In services of `type: LoadBalancer`, the default externalTrafficPolicy is `Cluster`, but may be overridden in order to [preserve the client IP][5] with `Local`.
 
 ```yaml
-  input:
-    tcp:
-      service:
-        type: LoadBalancer
-        externalTrafficPolicy: Local
-        loadBalancerIP:
-      ports:
-        - name: gelf1
-          port: 12222
-        - name: gelf2
-          port: 12223
-    udp:
-      service:
-        type: ClusterIP
-      ports:
-        - name: syslog
-          port: 5410
+input:
+  tcp:
+    service:
+      type: LoadBalancer
+      externalTrafficPolicy: Local
+      loadBalancerIP:
+    ports:
+      - name: gelf1
+        port: 12222
+      - name: gelf2
+        port: 12223
+  udp:
+    service:
+      type: ClusterIP
+    ports:
+      - name: syslog
+        port: 5410
 ```
 
 OR, if you want to expose only a single service with all the input ports open, you can do so by specifying the `service.ports` value:
 
 ```yaml
-  service:
-    ports:
-      - name: gelf
-        port: 12222
-        protocol: TCP
-      - name: syslog
-        port: 5410
-        protocol: UDP
+service:
+  ports:
+    - name: gelf
+      port: 12222
+      protocol: TCP
+    - name: syslog
+      port: 5410
+      protocol: UDP
 ```
 
 Note: Name must be in **IANA_SVC_NAME** format - at most 15 characters, matching regex **[a-z0-9]**, containing at least one letter, and hyphens cannot be adjacent to other hyphens
@@ -321,7 +319,7 @@ The certificates will be mounted into the `/etc/graylog/server`, so Inputs (e.g.
 those certificates with the following Input API configuration:
 
 | Parameter      | Value                           |
-|----------------|---------------------------------|
+| -------------- | ------------------------------- |
 | tls_cert_file: | /etc/graylog/server/server.cert |
 | tls_enable:    | true                            |
 | tls_key_file:  | /etc/graylog/server/server.key  |

--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -50,7 +50,7 @@ helm install --namespace "graylog" graylog kongz/graylog \
   --set tags.install-mongodb=false\
   --set tags.install-opensearch=false\
   --set graylog.mongodb.uri=mongodb://mongodb-mongodb-replicaset-0.mongodb-mongodb-replicaset.graylog.svc.cluster.local:27017/graylog?replicaSet=rs0 \
-  --set graylog.opensearch.hosts=http://opensearch-cluster-master.graylog.svc.cluster.local:9200
+  --set graylog.opensearch.hosts=http://opensearch-cluster-master-headless.graylog.svc.cluster.local:9200
   --set graylog.opensearch.version=7
 ```
 

--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -86,7 +86,7 @@ Or use chart dependencies with release name
 {{- else if .Values.graylog.opensearch.hosts }}
     {{- .Values.graylog.opensearch.hosts -}}
 {{- else }}
-    {{- printf "http://opensearch-cluster-master.%s.svc.cluster.local:9200" .Release.Namespace -}}
+    {{- printf "http://opensearch-cluster-master-headless.%s.svc.cluster.local:9200" .Release.Namespace -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -73,20 +73,20 @@ Print external URI
 {{- end -}}
 
 {{/*
-Create a default fully qualified elasticsearch name or use the `graylog.elasticsearch.hosts` value if defined.
+Create a default fully qualified opensearch name or use the `graylog.opensearch.hosts` value if defined.
 Or use chart dependencies with release name
 */}}
-{{- define "graylog.elasticsearch.hosts" -}}
-{{- if .Values.graylog.elasticsearch.uriSecretKey }}
-    {{- if .Values.graylog.elasticsearch.uriSSL }}
+{{- define "graylog.opensearch.hosts" -}}
+{{- if .Values.graylog.opensearch.uriSecretKey }}
+    {{- if .Values.graylog.opensearch.uriSSL }}
         {{- printf "https://${GRAYLOG_ELASTICSEARCH_HOSTS}" -}}
     {{- else }}
         {{- printf "http://${GRAYLOG_ELASTICSEARCH_HOSTS}" -}}
     {{- end }}
-{{- else if .Values.graylog.elasticsearch.hosts }}
-    {{- .Values.graylog.elasticsearch.hosts -}}
+{{- else if .Values.graylog.opensearch.hosts }}
+    {{- .Values.graylog.opensearch.hosts -}}
 {{- else }}
-    {{- printf "http://elasticsearch-master.%s.svc.cluster.local:9200" .Release.Namespace -}}
+    {{- printf "http://opensearch-cluster-master.%s.svc.cluster.local:9200" .Release.Namespace -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/graylog/templates/configmap.yaml
+++ b/charts/graylog/templates/configmap.yaml
@@ -98,7 +98,8 @@ data:
     http_external_uri = {{ $externalUri }}/
     {{- end }}
   {{- end }}
-    elasticsearch_hosts = {{ template "graylog.elasticsearch.hosts" . }}
+    elasticsearch_hosts = {{ template "graylog.opensearch.hosts" . }}
+    elasticsearch_disable_version_check = true
     allow_leading_wildcard_searches = {{ .Values.graylog.options.allowLeadingWildcardSearches }}
     allow_highlighting = {{ .Values.graylog.options.allowHighlighting }}
     output_batch_size = 500
@@ -228,12 +229,12 @@ data:
     echo "Starting graylog"
     # Original docker-entrypoint.sh in Graylog Docker will error while executing since you can't chown readonly files in `config`
     # exec /docker-entrypoint.sh graylog
-  {{- if or (.Values.graylog.elasticsearch.uriSecretKey) (.Values.graylog.mongodb.uriSecretKey) }}
+  {{- if or (.Values.graylog.opensearch.uriSecretKey) (.Values.graylog.mongodb.uriSecretKey) }}
     # Interpolate
     sed 's/"/\\\"/g;s/.*/echo "&"/e' ${GRAYLOG_HOME}/config/graylog.conf > ${GRAYLOG_HOME}/graylog.conf.subst
   {{- end }}
-  {{- if .Values.graylog.elasticsearch.version }}
-    export GRAYLOG_ELASTICSEARCH_VERSION={{ .Values.graylog.elasticsearch.version }}
+  {{- if .Values.graylog.opensearch.version }}
+    export GRAYLOG_ELASTICSEARCH_VERSION={{ .Values.graylog.opensearch.version }}
   {{- end }}
     echo "Graylog Home ${GRAYLOG_HOME}"
     echo "Graylog Plugin Dir ${GRAYLOG_PLUGIN_DIR}"
@@ -246,7 +247,7 @@ data:
       -Dgraylog2.installation_source=docker \
       ${GRAYLOG_HOME}/graylog.jar \
       server \
-    {{- if or (.Values.graylog.elasticsearch.uriSecretKey) (.Values.graylog.mongodb.uriSecretKey) }}
+    {{- if or (.Values.graylog.opensearch.uriSecretKey) (.Values.graylog.mongodb.uriSecretKey) }}
       -f ${GRAYLOG_HOME}/graylog.conf.subst
     {{- else }}
       -f ${GRAYLOG_HOME}/config/graylog.conf

--- a/charts/graylog/templates/configmap.yaml
+++ b/charts/graylog/templates/configmap.yaml
@@ -99,7 +99,8 @@ data:
     {{- end }}
   {{- end }}
     elasticsearch_hosts = {{ template "graylog.opensearch.hosts" . }}
-    elasticsearch_disable_version_check = true
+    elasticsearch_discovery_enabled = false
+    # elasticsearch_disable_version_check = true
     allow_leading_wildcard_searches = {{ .Values.graylog.options.allowLeadingWildcardSearches }}
     allow_highlighting = {{ .Values.graylog.options.allowHighlighting }}
     output_batch_size = 500

--- a/charts/graylog/templates/statefulset.yaml
+++ b/charts/graylog/templates/statefulset.yaml
@@ -118,12 +118,12 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.graylog.existingRootSecret | default (include "graylog.fullname" .) }}
                   key: graylog-password-sha2
-            {{- if .Values.graylog.elasticsearch.uriSecretKey }}
+            {{- if .Values.graylog.opensearch.uriSecretKey }}
             - name: GRAYLOG_ELASTICSEARCH_HOSTS
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.graylog.elasticsearch.uriSecretName | default (printf "%s-es" (include "graylog.fullname" .)) }}
-                  key: {{ .Values.graylog.elasticsearch.uriSecretKey }}
+                  name: {{ .Values.graylog.opensearch.uriSecretName | default (printf "%s-es" (include "graylog.fullname" .)) }}
+                  key: {{ .Values.graylog.opensearch.uriSecretKey }}
             {{- end }}
             {{- if .Values.graylog.mongodb.uriSecretKey }}
             - name: GRAYLOG_MONGODB_URI

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -567,18 +567,18 @@ graylog:
 opensearch:
   enabled: true
   extraEnvs:
-  - name: plugins.security.ssl.http.enabled
-    value: "false"
-  - name: plugins.security.disabled
-    value: "true"
+    - name: plugins.security.ssl.http.enabled
+      value: "false"
+    - name: plugins.security.disabled
+      value: "true"
   # - name: OPENSEARCH_JAVA_OPTS
   #   value: "-Xms512m -Xmx512m"
-    
-    # - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
-      # - "discovery.seed_hosts=opensearch2,opensearch3"
-      # - "cluster.initial_master_nodes=opensearch1,opensearch2,opensearch3"
-      # - "bootstrap.memory_lock=true"
-      # - "action.auto_create_index=false"
+
+  # - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+  # - "discovery.seed_hosts=opensearch2,opensearch3"
+  # - "cluster.initial_master_nodes=opensearch1,opensearch2,opensearch3"
+  # - "bootstrap.memory_lock=true"
+  # - "action.auto_create_index=false"
   # resources:
   #   requests:
   #     cpu: "100m"

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -25,8 +25,8 @@ serviceAccount:
   annotations: {}
 
 tags:
-  # If true, this chart will install Elasticsearch from requirement dependencies
-  install-elasticsearch: true
+  # If true, this chart will install opensearch from requirement dependencies
+  install-opensearch: true
   # If true, this chart will install MongoDB replicaset from requirement dependencies
   install-mongodb: true
 
@@ -59,6 +59,7 @@ graylog:
     pullPolicy: "IfNotPresent"
 
   ## Graylog default Java option
+  # javaOpts: "-Dlog4j2.formatMsgNoLookups=true -Djdk.tls.acknowledgeCloseNotify=true -XX:+UnlockExperimentalVMOptions -XX:-OmitStackTraceInFastThrow -XX:+UseG1GC -server"
   javaOpts: "-Dlog4j2.formatMsgNoLookups=true -Djdk.tls.acknowledgeCloseNotify=true -XX:+UnlockExperimentalVMOptions -XX:-OmitStackTraceInFastThrow -XX:+UseG1GC -server"
 
   ## Number of Graylog instance
@@ -349,7 +350,7 @@ graylog:
   ## Set Graylog Java heapsize. If this value empty, chart will allocate heapsize using `-XX:+UseCGroupMemoryLimitForHeap`
   ## ref: https://blogs.oracle.com/java-platform-group/java-se-support-for-docker-cpu-and-memory-limits
   ##
-  # heapSize: "1024g"
+  heapSize: "16g"
 
   ## RollingUpdate update strategy
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
@@ -399,16 +400,17 @@ graylog:
   ##
   existingRootSecret: ""
 
-  elasticsearch:
+  opensearch:
     ## Major version of the Elasticsearch version used.
     ## It is required by Graylog 4. See https://docs.graylog.org/en/4.0/pages/configuration/elasticsearch.html#available-elasticsearch-configuration-tunables
-    version: "7"
+    # version: "7"
+
     ## List of Elasticsearch hosts Graylog should connect to.
     ## Need to be specified as a comma-separated list of valid URIs for the http ports of your elasticsearch nodes.
     ## If one or more of your elasticsearch hosts require authentication, include the credentials in each node URI that
     ## requires authentication.
     ##
-    # hosts: http://elasticsearch-client.graylog.svc.cluster.local:9200
+    # hosts: http://opensearch-cluster-master.graylog.svc.cluster.local:9200
     hosts: ""
     # Allow elasticsearch hosts to be fetched from a k8s secret
     # {{ graylog.fullname }}-es will be used as uriSecretName if left empty
@@ -562,29 +564,19 @@ graylog:
     inputbufferProcessors: 2
     processbufferProcessors: 5
 
-## Specify Elasticsearch version from requirement dependencies. Ignore this seection if you install Elasticsearch manually.
-##
-## Note: the official elasticsearch chart will install master, coordinate, data, and ingest in single node.
-## It is strongly recommend to install Elasticsearch manually without using the dependency.
-## To install Elasticsearch on production, please follow the official guide https://github.com/elastic/helm-charts/tree/main/elasticsearch#how-to-deploy-dedicated-nodes-types
-elasticsearch:
-  replicas: 1
-  minimumMasterNodes: 1
-  antiAffinity: "soft"
-  # Shrink default JVM heap.
-  esJavaOpts: "-Xmx128m -Xms128m"
-  # Allocate smaller chunks of memory per pod.
-  resources:
-    requests:
-      cpu: "100m"
-      memory: "512M"
-    limits:
-      cpu: "1000m"
-      memory: "512M"
-  volumeClaimTemplate:
-    resources:
-      requests:
-        storage: 8Gi # default 30Gi
+opensearch:
+  enabled: true
+  # resources:
+  #   requests:
+  #     cpu: "100m"
+  #     memory: "512M"
+  #   limits:
+  #     cpu: "1000m"
+  #     memory: "512M"
+  # volumeClaimTemplate:
+  #   resources:
+  #     requests:
+  #       storage: 30Gi # default 30Gi
 
 # Specify Mongodb settings. Ignore this section if you install MongoDB manually.
 mongodb:

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -344,8 +344,8 @@ graylog:
     limits:
       cpu: "1"
     requests:
-      cpu: "500m"
-      memory: "1024Mi"
+      cpu: "200m"
+      memory: "512Mi"
 
   ## Set Graylog Java heapsize. If this value empty, chart will allocate heapsize using `-XX:+UseCGroupMemoryLimitForHeap`
   ## ref: https://blogs.oracle.com/java-platform-group/java-se-support-for-docker-cpu-and-memory-limits

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -416,7 +416,7 @@ graylog:
     # {{ graylog.fullname }}-es will be used as uriSecretName if left empty
     uriSecretName: ""
     uriSecretKey: ""
-    uriSSL: true
+    uriSSL: false
 
   mongodb:
     ## MongoDB connection string

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -344,8 +344,8 @@ graylog:
     limits:
       cpu: "1"
     requests:
-      cpu: "500m"
-      memory: "1024Mi"
+      cpu: "200m"
+      memory: "512Mi"
 
   ## Set Graylog Java heapsize. If this value empty, chart will allocate heapsize using `-XX:+UseCGroupMemoryLimitForHeap`
   ## ref: https://blogs.oracle.com/java-platform-group/java-se-support-for-docker-cpu-and-memory-limits
@@ -566,6 +566,10 @@ graylog:
 
 opensearch:
   enabled: true
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "512M"
   extraEnvs:
     - name: plugins.security.ssl.http.enabled
       value: "false"

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -410,13 +410,13 @@ graylog:
     ## If one or more of your elasticsearch hosts require authentication, include the credentials in each node URI that
     ## requires authentication.
     ##
-    # hosts: http://opensearch-cluster-master.graylog.svc.cluster.local:9200
+    # hosts: http://opensearch-cluster-master-headless.graylog.svc.cluster.local:9200
     hosts: ""
     # Allow elasticsearch hosts to be fetched from a k8s secret
     # {{ graylog.fullname }}-es will be used as uriSecretName if left empty
     uriSecretName: ""
     uriSecretKey: ""
-    uriSSL: false
+    uriSSL: true
 
   mongodb:
     ## MongoDB connection string
@@ -566,6 +566,19 @@ graylog:
 
 opensearch:
   enabled: true
+  extraEnvs:
+  - name: plugins.security.ssl.http.enabled
+    value: "false"
+  - name: plugins.security.disabled
+    value: "true"
+  # - name: OPENSEARCH_JAVA_OPTS
+  #   value: "-Xms512m -Xmx512m"
+    
+    # - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+      # - "discovery.seed_hosts=opensearch2,opensearch3"
+      # - "cluster.initial_master_nodes=opensearch1,opensearch2,opensearch3"
+      # - "bootstrap.memory_lock=true"
+      # - "action.auto_create_index=false"
   # resources:
   #   requests:
   #     cpu: "100m"

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -55,11 +55,11 @@ graylog:
   ##
   image:
     repository: "graylog/graylog"
-    tag: "4.2.3-1"
+    tag: "5.0.2"
     pullPolicy: "IfNotPresent"
 
   ## Graylog default Java option
-  javaOpts: "-Dlog4j2.formatMsgNoLookups=true -Djdk.tls.acknowledgeCloseNotify=true -XX:+UnlockExperimentalVMOptions -XX:NewRatio=1 -XX:MaxMetaspaceSize=256m -server -XX:+ResizeTLAB -XX:-OmitStackTraceInFastThrow"
+  javaOpts: "-Dlog4j2.formatMsgNoLookups=true -Djdk.tls.acknowledgeCloseNotify=true -XX:+UnlockExperimentalVMOptions -XX:-OmitStackTraceInFastThrow -XX:+UseG1GC -server"
 
   ## Number of Graylog instance
   ##
@@ -90,7 +90,8 @@ graylog:
   ## Node tolerations for node-exporter scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##
-  tolerations: []
+  tolerations:
+    []
     # - key: "key"
     #   operator: "Equal|Exists"
     #   value: "value"
@@ -112,7 +113,8 @@ graylog:
   ## Set security context for defining privilege and accessing control settings entire Pod
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
-  podSecurityContext: {}
+  podSecurityContext:
+    {}
     # runAsUser: 10001
     # fsGroup: 65534
 
@@ -237,7 +239,8 @@ graylog:
   ## Note: Name must be in IANA_SVC_NAME (at most 15 characters, matching regex [a-z0-9]([a-z0-9-]*[a-z0-9])* and it must contains at least one letter [a-z], hyphens cannot be adjacent to other hyphens)
   ## Note: Array must be sorted by port order
   ##
-  input: {}
+  input:
+    {}
     # tcp:
     #   service:
     #     name: your-tcp-service-name
@@ -332,7 +335,6 @@ graylog:
     ## Please note that tls secret should reside in istio-system namespace
     ## leave blanc for disabling TLS
     tlsSecretName: ""
-
 
   ## Configure resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -488,7 +490,8 @@ graylog:
   ## Additional server files will be deployed to /etc/graylog/server
   ## For example, you can put server certificates or authorized clients certificates here
   ##
-  serverFiles: {}
+  serverFiles:
+    {}
     # server.key: |
     # server.cert: |
 
@@ -581,7 +584,7 @@ elasticsearch:
   volumeClaimTemplate:
     resources:
       requests:
-        storage: 8Gi  # default 30Gi
+        storage: 8Gi # default 30Gi
 
 # Specify Mongodb settings. Ignore this section if you install MongoDB manually.
 mongodb:

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -344,8 +344,8 @@ graylog:
     limits:
       cpu: "1"
     requests:
-      cpu: "200m"
-      memory: "512Mi"
+      cpu: "500m"
+      memory: "1024Mi"
 
   ## Set Graylog Java heapsize. If this value empty, chart will allocate heapsize using `-XX:+UseCGroupMemoryLimitForHeap`
   ## ref: https://blogs.oracle.com/java-platform-group/java-se-support-for-docker-cpu-and-memory-limits
@@ -566,10 +566,6 @@ graylog:
 
 opensearch:
   enabled: true
-  resources:
-    requests:
-      cpu: "100m"
-      memory: "512M"
   extraEnvs:
     - name: plugins.security.ssl.http.enabled
       value: "false"

--- a/ct.yaml
+++ b/ct.yaml
@@ -3,7 +3,6 @@ chart-dirs:
   - charts
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
-  - elastic=https://helm.elastic.co
   - stable=https://charts.helm.sh/stable
   - kongz=https://charts.kong-z.com
   - opensearch=https://opensearch-project.github.io/helm-charts

--- a/ct.yaml
+++ b/ct.yaml
@@ -4,6 +4,6 @@ chart-dirs:
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
   - stable=https://charts.helm.sh/stable
-  - kongz=https://charts.kong-z.com
+  - luizjr=https://charts.luizjr.dev
   - opensearch=https://opensearch-project.github.io/helm-charts
 target-branch: main

--- a/ct.yaml
+++ b/ct.yaml
@@ -6,4 +6,5 @@ chart-repos:
   - elastic=https://helm.elastic.co
   - stable=https://charts.helm.sh/stable
   - kongz=https://charts.kong-z.com
+  - opensearch=https://opensearch-project.github.io/helm-charts
 target-branch: main

--- a/ct.yaml
+++ b/ct.yaml
@@ -4,6 +4,6 @@ chart-dirs:
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
   - stable=https://charts.helm.sh/stable
-  - luizjr=https://charts.luizjr.dev
+  - kongz=https://charts.kong-z.com
   - opensearch=https://opensearch-project.github.io/helm-charts
 target-branch: main


### PR DESCRIPTION
I made the necessary changes to switch from Elasticserach to Opensearch, already using Mongo 6 with Graylog 5.

I'm starting from scratch, I still don't know the impact it can have on applications that are already online... because it's a logging tool, I programmed the update and simply killed the old one and started this update from scratch and it worked fine ...