### PR TITLE
Replace deprecated UseCGroupMemoryLimitForHeap

### DIFF
--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 2.3.1
+version: 2.3.2
 appVersion: 5.0.3
 description: Graylog is the centralized log management solution built to open
   standards for capturing, storing, and enabling real-time analysis of terabytes

--- a/charts/graylog/templates/statefulset.yaml
+++ b/charts/graylog/templates/statefulset.yaml
@@ -106,7 +106,7 @@ spec:
               {{- if .Values.graylog.heapSize }}
               value: "{{ $javaOpts }} {{ printf "-Xms%s -Xmx%s" .Values.graylog.heapSize .Values.graylog.heapSize}}"
               {{- else }}
-              value: "{{ $javaOpts }} -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+              value: "{{ $javaOpts }} -XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport"
               {{- end }}
             - name: GRAYLOG_PASSWORD_SECRET
               valueFrom:


### PR DESCRIPTION
Replace deprecated `UseCGroupMemoryLimitForHeap` with `UseContainerSupport`. Now if you leave empty the `javaHeap` parameter , it won't start due to :

```
Graylog Elasticsearch Version 7
Unrecognized VM option 'UseCGroupMemoryLimitForHeap'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```


# What this PR does / why we need it
If leaving empty the heapSize, it will not deploy due to unrecognized option

# Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/KongZ/charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
