### PR TITLE
#146   image tag is missing for alpine containers

### DIFF
--- a/charts/graylog/templates/statefulset.yaml
+++ b/charts/graylog/templates/statefulset.yaml
@@ -51,11 +51,13 @@ spec:
 {{- if .Values.graylog.priorityClassName }}
       priorityClassName: {{ .Values.graylog.priorityClassName }}
 {{- end }}
-      securityContext:
+      securityContext
         {{- toYaml .Values.graylog.podSecurityContext | nindent 8 }}
       initContainers:
         - name: "setup"
+          registry: {{ .Values.graylog.init.image.registry | default "docker.io" }}
           image: {{ .Values.graylog.init.image.repository | default "busybox" }}
+          tag: {{ .Values.graylog.init.image.tag | default "latest" }}
           imagePullPolicy: {{ .Values.graylog.init.image.pullPolicy | default "IfNotPresent" }}
           # Graylog journal will recursive in every subdirectories. Any invalid format directories will cause errors
           command:

--- a/charts/graylog/templates/statefulset.yaml
+++ b/charts/graylog/templates/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
 {{- if .Values.graylog.priorityClassName }}
       priorityClassName: {{ .Values.graylog.priorityClassName }}
 {{- end }}
-      securityContext
+      securityContext:
         {{- toYaml .Values.graylog.podSecurityContext | nindent 8 }}
       initContainers:
         - name: "setup"

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -473,7 +473,9 @@ graylog:
     ## Init Container image
     ##
     image:
+      registry: "docker.io"
       repository: "alpine"
+      tag: "3.18.0"
       pullPolicy: "IfNotPresent"
 
     ## Set kubectl location to download and use on init-container. If the value is not set, the https://storage.googleapis.com/kubernetes-release/ will be used.


### PR DESCRIPTION
**Describe the bug**
No tag is specified for init container. latest is used


**Which version of the chart**: 

2.3.2


**What you expected to happen**:
Allow to specify `init.env.image.tag` with `init.env.image.repository`

