### PR TITLE
Add max unavailable field.

### DIFF
--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 2.3.2
+version: 2.3.3
 appVersion: 5.0.3
 description: Graylog is the centralized log management solution built to open
   standards for capturing, storing, and enabling real-time analysis of terabytes

--- a/charts/graylog/templates/statefulset.yaml
+++ b/charts/graylog/templates/statefulset.yaml
@@ -15,6 +15,10 @@ spec:
 {{ include "graylog.selectorLabels" . | indent 6 }}
   updateStrategy:
     type: {{ .Values.graylog.updateStrategy }}
+    {{- if .Values.graylog.maxUnavailable }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.graylog.maxUnavailable }}
+    {{- end }}
   template:
     metadata:
       labels:

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -356,7 +356,10 @@ graylog:
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   ##
   updateStrategy: RollingUpdate
-  #maxUnavailable: 10%
+  ## Control the maximum number of Pods that can be unavailable during an update 
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#maximum-unavailable-pods
+  ##
+  # maxUnavailable: 10%
 
   ## Graylog server pod termination grace period
   ##

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -356,7 +356,7 @@ graylog:
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   ##
   updateStrategy: RollingUpdate
-  ## Control the maximum number of Pods that can be unavailable during an update 
+  ## Control the maximum number of Pods that can be unavailable during an update
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#maximum-unavailable-pods
   ##
   # maxUnavailable: 10%

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -356,6 +356,7 @@ graylog:
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   ##
   updateStrategy: RollingUpdate
+  #maxUnavailable: 10%
 
   ## Graylog server pod termination grace period
   ##


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/KongZ/charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->

# What this PR does / why we need it

This PR adds the [maxUnavailable](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#rollingupdatestatefulsetstrategy-v1-apps). This is a useful field for some users of Graylog, as it'll allow customization of rollout speeds.

# Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- No issue is opened but this is an issue we've been experiencing. 

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/KongZ/charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
