### PR TITLE
Only download kubectl and provide volume if graylog version is < 4.2.0-0

### DIFF
--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 2.3.4
+version: 2.3.5
 appVersion: 5.0.3
 description: Graylog is the centralized log management solution built to open
   standards for capturing, storing, and enabling real-time analysis of terabytes

--- a/charts/graylog/templates/statefulset.yaml
+++ b/charts/graylog/templates/statefulset.yaml
@@ -7,6 +7,7 @@ metadata:
 {{- with .Values.graylog.customLabels }}
 {{ . | toYaml | indent 4 }}
 {{- end }}
+{{ $graylogVersion := .Values.graylog.image.tag | default .Chart.AppVersion }}
 spec:
   serviceName: {{ template "graylog.service.headless.name" . }}
   replicas: {{ .Values.graylog.replicas }}
@@ -72,12 +73,14 @@ spec:
               rm -rf /usr/share/graylog/data/journal/messagejournal-0
               rm -rf /usr/share/graylog/data/journal/recovery-point-offset-checkpoint
             {{- end }}
+            {{- if semverCompare "< 4.2.0-0" ( $graylogVersion ) }}
               {{- if .Values.graylog.init.kubectlLocation }}
               wget {{ .Values.graylog.init.kubectlLocation }} -O /k8s/kubectl
               {{- else }}
               wget https://storage.googleapis.com/kubernetes-release/release/{{ .Values.graylog.init.kubectlVersion | default .Capabilities.KubeVersion.Version }}/bin/linux/amd64/kubectl -O /k8s/kubectl
               {{- end }}
               chmod +x /k8s/kubectl
+            {{- end }}
 
               GRAYLOG_HOME=/usr/share/graylog
               chown -R 1100:1100 ${GRAYLOG_HOME}/data/
@@ -89,8 +92,10 @@ spec:
           volumeMounts:
             - name: journal
               mountPath: /usr/share/graylog/data/journal
+            {{- if semverCompare "< 4.2.0-0" ( $graylogVersion ) }}
             - name: kubectl
               mountPath: /k8s
+            {{- end }}
 {{- if .Values.graylog.init.resources }}
           resources:
 {{ toYaml .Values.graylog.init.resources | indent 12 }}
@@ -224,12 +229,13 @@ spec:
             - name: files
               mountPath: /etc/graylog/server
           {{- end }}
+          {{- if semverCompare "< 4.2.0-0" ( $graylogVersion ) }}
             - name: kubectl
               mountPath: /k8s
+          {{- end }}
           {{- if .Values.graylog.extraVolumeMounts }}
           {{ toYaml .Values.graylog.extraVolumeMounts | nindent 12 }}
           {{- end }}
-          {{ $graylogVersion := .Values.graylog.image.tag | default .Chart.AppVersion }}
           {{- if semverCompare "< 4.2.0-0" ( $graylogVersion ) }}
           lifecycle:
             preStop:
@@ -271,8 +277,10 @@ spec:
           configMap:
             name: {{ template "graylog.fullname" . }}-files
         {{- end }}
+        {{- if semverCompare "< 4.2.0-0" ( $graylogVersion ) }}
         - name: kubectl
           emptyDir: {}
+        {{- end }}
         {{- if .Values.graylog.extraVolumes }}
         {{ toYaml .Values.graylog.extraVolumes | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/KongZ/charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->

#  Only download kubectl and provide volume if graylog version is < 4.2.0-0

I recognized that the kubectl is always downloaded. But it is only used in the lifecycle whe tne graylog version is < 4.2.0-0

# Which issue this PR fixes

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x ] [DCO](https://github.com/KongZ/charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ x] Chart Version bumped
