### PR TITLE
feat(graylog): include podsecurity and securitycontext in chart, activate by default

### DIFF
--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 2.3.5
+version: 2.3.6
 appVersion: 5.0.3
 description: Graylog is the centralized log management solution built to open
   standards for capturing, storing, and enabling real-time analysis of terabytes

--- a/charts/graylog/templates/statefulset.yaml
+++ b/charts/graylog/templates/statefulset.yaml
@@ -55,8 +55,10 @@ spec:
 {{- if .Values.graylog.priorityClassName }}
       priorityClassName: {{ .Values.graylog.priorityClassName }}
 {{- end }}
+{{- if .Values.graylog.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.graylog.podSecurityContext | nindent 8 }}
+{{- end }}
       initContainers:
         - name: "setup"
           image: {{ .Values.graylog.init.image.repository | default "busybox" }}
@@ -81,6 +83,10 @@ spec:
 
               GRAYLOG_HOME=/usr/share/graylog
               chown -R 1100:1100 ${GRAYLOG_HOME}/data/
+{{- if .Values.graylog.securityContext }}
+          securityContext:
+            {{- toYaml .Values.graylog.securityContext | nindent 12 }}
+{{- end }}
           env:
             {{- range $key, $value := .Values.graylog.init.env }}
             - name: {{ $key }}
@@ -145,8 +151,10 @@ spec:
                 {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- end }}
+{{- if .Values.graylog.securityContext }}
           securityContext:
             {{- toYaml .Values.graylog.securityContext | nindent 12 }}
+{{- end}}
           ports:
             - containerPort: 9000
               name: graylog

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -115,15 +115,19 @@ graylog:
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
   podSecurityContext:
-    {}
-    # runAsUser: 10001
-    # fsGroup: 65534
-
+    fsGroup: 1100
+    fsGroupChangePolicy: Always
   ## Set security context for defining privilege and accessing control settings for Graylog container
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
   securityContext:
-    privileged: false
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    runAsUser: 1100
+    runAsGroup: 1100
     # capabilities:
     #   drop:
     #   - ALL


### PR DESCRIPTION
# What this PR does / why we need it

This is a simple PR to add the configuration for securityContext and podSecurityContext to work by default and allow graylog to run as user 1100. Previously users had to provide this and it was missing in the init container.

# Special notes for your reviewer

If people upgrade but were specifying these values nothing different should happen.

# Checklist
- [x] [DCO](https://github.com/KongZ/charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
