### PR TITLE
Fix security policy in init container

### DIFF
--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 2.3.6
-appVersion: 5.0.3
+version: 2.3.7
+appVersion: 5.2.6
 description: Graylog is the centralized log management solution built to open
   standards for capturing, storing, and enabling real-time analysis of terabytes
   of machine data.

--- a/charts/graylog/templates/statefulset.yaml
+++ b/charts/graylog/templates/statefulset.yaml
@@ -77,16 +77,15 @@ spec:
               {{- if .Values.graylog.init.kubectlLocation }}
               wget {{ .Values.graylog.init.kubectlLocation }} -O /k8s/kubectl
               {{- else }}
-              wget https://storage.googleapis.com/kubernetes-release/release/{{ .Values.graylog.init.kubectlVersion | default .Capabilities.KubeVersion.Version }}/bin/linux/amd64/kubectl -O /k8s/kubectl
+              {{.Capabilities.KubeVersion}}
+              wget https://dl.k8s.io/release/{{ .Values.graylog.init.kubectlVersion | default (regexReplaceAll "-.+" .Capabilities.KubeVersion.Version "") }}/bin/linux/amd64/kubectl -O /k8s/kubectl
               {{- end }}
               chmod +x /k8s/kubectl
 
               GRAYLOG_HOME=/usr/share/graylog
               chown -R 1100:1100 ${GRAYLOG_HOME}/data/
-{{- if .Values.graylog.securityContext }}
           securityContext:
-            {{- toYaml .Values.graylog.securityContext | nindent 12 }}
-{{- end }}
+            runAsUser: 0 # We require permission to change the volume owner
           env:
             {{- range $key, $value := .Values.graylog.init.env }}
             - name: {{ $key }}

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -55,7 +55,7 @@ graylog:
   ##
   image:
     repository: "graylog/graylog"
-    tag: "5.0.3"
+    tag: "5.2.6"
     pullPolicy: "IfNotPresent"
 
   ## Graylog default Java option
@@ -220,12 +220,20 @@ graylog:
       ##
       type: ClusterIP
 
+  ## Override startupProbe config (path not allowed).
+  ## In a typical Graylog deployment, it can take up to 60 seconds for OpenSearch and MongoDB to become fully available. 
+  ## This wait time can be reduced if your system has faster startup times.
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes
+  ##
   startupProbe:
     periodSeconds: 60
     failureThreshold: 3
     successThreshold: 1
     timeoutSeconds: 5
 
+  ## Override livenessProbe config (path not allowed)
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-http-request
+  ##
   livenessProbe:
     initialDelaySeconds: 0
     periodSeconds: 30
@@ -233,6 +241,9 @@ graylog:
     successThreshold: 1
     timeoutSeconds: 5
 
+  ## Override readinessProbe config (path not allowed)
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-http-request
+  ##
   readinessProbe:
     initialDelaySeconds: 0
     periodSeconds: 10
@@ -491,10 +502,10 @@ graylog:
       repository: "alpine"
       pullPolicy: "IfNotPresent"
 
-    ## Set kubectl location to download and use on init-container. If the value is not set, the https://storage.googleapis.com/kubernetes-release/ will be used.
+    ## Set kubectl location to download and use on init-container. If the value is not set, the https://dl.k8s.io/release/ will be used.
     ##
     kubectlLocation: ""
-    ## Set kubectl command version to download from https://storage.googleapis.com/kubernetes-release/. If the value is not set, default value is .Capabilities.KubeVersion.Version
+    ## Set kubectl command version to download from https://dl.k8s.io/release/. If the value is not set, default value is .Capabilities.KubeVersion.Version
     ##
     # kubectlVersion: "v1.20"
 
@@ -586,21 +597,15 @@ opensearch:
       value: "false"
     - name: plugins.security.disabled
       value: "true"
-  # - name: OPENSEARCH_JAVA_OPTS
-  #   value: "-Xms512m -Xmx512m"
-
-  # - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
-  # - "discovery.seed_hosts=opensearch2,opensearch3"
-  # - "cluster.initial_master_nodes=opensearch1,opensearch2,opensearch3"
-  # - "bootstrap.memory_lock=true"
-  # - "action.auto_create_index=false"
-  # resources:
-  #   requests:
-  #     cpu: "100m"
-  #     memory: "512M"
+  ## Set default resource very low. This help reduce resources usage on GitHub Action when performing chart-testing.
+  opensearchJavaOpts: "-Xmx128M -Xms128M"
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "100Mi"
   #   limits:
   #     cpu: "1000m"
-  #     memory: "512M"
+  #     memory: "512Mi"
   # volumeClaimTemplate:
   #   resources:
   #     requests:

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -221,7 +221,7 @@ graylog:
       type: ClusterIP
 
   ## Override startupProbe config (path not allowed).
-  ## In a typical Graylog deployment, it can take up to 60 seconds for OpenSearch and MongoDB to become fully available. 
+  ## In a typical Graylog deployment, it can take up to 60 seconds for OpenSearch and MongoDB to become fully available.
   ## This wait time can be reduced if your system has faster startup times.
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes
   ##


### PR DESCRIPTION
# What this PR does / why we need it
To modify ownership of data directories, the Init-container needs root privileges. This PR will fix #158 
The kubectl download URL requires correction.
Updates the default Graylog version.

# Which issue this PR fixes
- fixes #158 

# Special notes for your reviewer

# Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/KongZ/charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
