### PR TITLE
Auto-detect graylog leader and remove kubectl download

### DIFF
--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 2.3.7
+version: 2.3.8
 appVersion: 5.2.6
 description: Graylog is the centralized log management solution built to open
   standards for capturing, storing, and enabling real-time analysis of terabytes

--- a/charts/graylog/templates/configmap.yaml
+++ b/charts/graylog/templates/configmap.yaml
@@ -141,7 +141,9 @@ data:
     transport_email_web_interface_url = {{ $externalUri }}
   {{- end }}
     content_packs_dir = /usr/share/graylog/data/contentpacks
+  {{- if semverCompare "~5" ( $graylogVersion ) }}
     content_packs_auto_load = grok-patterns.json
+  {{- end}}
     proxied_requests_thread_pool_size = 32
   {{- if .Values.graylog.metrics.enabled }}
     prometheus_exporter_enabled = true
@@ -199,6 +201,15 @@ data:
   {{- end }}
     # Start Graylog
     echo "Starting graylog"
+    if [[ ! -z "${POD_NAME}" ]]
+    then
+      if echo "${POD_NAME}" | grep "\\-0$" >/dev/null
+      then
+        export GRAYLOG_IS_LEADER="true"
+      else
+        export GRAYLOG_IS_LEADER="false"
+      fi
+    fi
     # Original docker-entrypoint.sh in Graylog Docker will error while executing since you can't chown readonly files in `config`
     # exec /docker-entrypoint.sh graylog
   {{- if or (.Values.graylog.opensearch.uriSecretKey) (.Values.graylog.mongodb.uriSecretKey) }}
@@ -209,6 +220,7 @@ data:
     export GRAYLOG_ELASTICSEARCH_VERSION={{ .Values.graylog.opensearch.version }}
   {{- end }}
     echo "Graylog Home ${GRAYLOG_HOME}"
+    echo "Graylog Leader ${GRAYLOG_IS_LEADER}"
     echo "Graylog Plugin Dir ${GRAYLOG_PLUGIN_DIR}"
     echo "Graylog Elasticsearch Version ${GRAYLOG_ELASTICSEARCH_VERSION}"
     "${JAVA_HOME}/bin/java" \

--- a/charts/graylog/templates/configmap.yaml
+++ b/charts/graylog/templates/configmap.yaml
@@ -163,8 +163,6 @@ data:
     export GRAYLOG_PLUGIN_DIR=${GRAYLOG_HOME}/plugin
     # Graylog 4.0.2 images move plugin dir to `plugins-default`
     find ${GRAYLOG_HOME}/plugins-default/ -type f -exec cp {} ${GRAYLOG_PLUGIN_DIR} \;
-    # Looking for Master IP
-    retry=1
     # Download plugins
   {{- if .Values.graylog.plugins.proxy.enabled }}
     export https_proxy={{ .Values.graylog.plugins.proxy.host }}

--- a/charts/graylog/templates/configmap.yaml
+++ b/charts/graylog/templates/configmap.yaml
@@ -149,6 +149,7 @@ data:
   {{- end }}
   {{- if .Values.graylog.trustedProxies }}
     trusted_proxies = {{.Values.graylog.trustedProxies}}
+    data_dir = /usr/share/graylog/data
   {{- end }}
   {{- if .Values.graylog.config }}
 {{ .Values.graylog.config | indent 4 }}
@@ -162,36 +163,6 @@ data:
     find ${GRAYLOG_HOME}/plugins-default/ -type f -exec cp {} ${GRAYLOG_PLUGIN_DIR} \;
     # Looking for Master IP
     retry=1
-    for i in {0..2}
-    do
-      MASTER_IP=`/k8s/kubectl --namespace {{ .Release.Namespace }} get pod -o jsonpath='{range .items[*]}{.metadata.name} {.status.podIP}{"\n"}{end}' -l graylog-role=master --field-selector=status.phase=Running|awk '{print $2}'`
-      SELF_IP=`/k8s/kubectl --namespace {{ .Release.Namespace }} get pod $HOSTNAME -o jsonpath='{.status.podIP}'`
-      echo "Current master is $MASTER_IP"
-      echo "Self IP is $SELF_IP"
-      retry=$((retry+1))
-      [[ ! -z "$MASTER_IP" ]] && break
-      echo "[Try ${retry}/3] Waiting for master node..."
-      sleep 2
-    done
-    if [[ -z "$MASTER_IP" ]]; then
-      echo "Launching $HOSTNAME as master"
-      export GRAYLOG_IS_MASTER="true"
-      export GRAYLOG_IS_LEADER="true"
-      /k8s/kubectl --namespace {{ .Release.Namespace }} label --overwrite pod $HOSTNAME graylog-role="master"
-    else
-      # When container was recreated or restart, MASTER_IP == SELF_IP, running as master and no need to change label graylog-role="master"
-      if [ "$SELF_IP" == "$MASTER_IP" ];then
-        echo "Launching $HOSTNAME as master"
-        export GRAYLOG_IS_MASTER="true"
-        export GRAYLOG_IS_LEADER="true"
-      else
-        # MASTER_IP != SELF_IP, running as coordinating
-        echo "Launching $HOSTNAME as coordinating"
-        export GRAYLOG_IS_MASTER="false"
-        export GRAYLOG_IS_LEADER="false"
-        /k8s/kubectl --namespace {{ .Release.Namespace }} label --overwrite pod $HOSTNAME graylog-role="coordinating"
-      fi
-    fi
     # Download plugins
   {{- if .Values.graylog.plugins.proxy.enabled }}
     export https_proxy={{ .Values.graylog.plugins.proxy.host }}

--- a/charts/graylog/templates/statefulset.yaml
+++ b/charts/graylog/templates/statefulset.yaml
@@ -74,14 +74,6 @@ spec:
               rm -rf /usr/share/graylog/data/journal/messagejournal-0
               rm -rf /usr/share/graylog/data/journal/recovery-point-offset-checkpoint
             {{- end }}
-              {{- if .Values.graylog.init.kubectlLocation }}
-              wget {{ .Values.graylog.init.kubectlLocation }} -O /k8s/kubectl
-              {{- else }}
-              {{.Capabilities.KubeVersion}}
-              wget https://dl.k8s.io/release/{{ .Values.graylog.init.kubectlVersion | default (regexReplaceAll "-.+" .Capabilities.KubeVersion.Version "") }}/bin/linux/amd64/kubectl -O /k8s/kubectl
-              {{- end }}
-              chmod +x /k8s/kubectl
-
               GRAYLOG_HOME=/usr/share/graylog
               chown -R 1100:1100 ${GRAYLOG_HOME}/data/
           securityContext:
@@ -94,8 +86,6 @@ spec:
           volumeMounts:
             - name: journal
               mountPath: /usr/share/graylog/data/journal
-            - name: kubectl
-              mountPath: /k8s
 {{- if .Values.graylog.init.resources }}
           resources:
 {{ toYaml .Values.graylog.init.resources | indent 12 }}
@@ -110,6 +100,12 @@ spec:
           command:
             - /entrypoint.sh
           env:
+            # Kubernetes Auto Master Selection
+            # https://go2docs.graylog.org/5-0/downloading_and_installing_graylog/docker_installation.htm#KubernetesAutomaticMasterSelection
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: GRAYLOG_SERVER_JAVA_OPTS
               {{- $javaOpts := .Values.graylog.javaOpts }}
               {{- if .Values.graylog.heapSize }}
@@ -231,13 +227,10 @@ spec:
             - name: files
               mountPath: /etc/graylog/server
           {{- end }}
-            - name: kubectl
-              mountPath: /k8s
+
           {{- if .Values.graylog.extraVolumeMounts }}
           {{ toYaml .Values.graylog.extraVolumeMounts | nindent 12 }}
           {{- end }}
-          {{ $graylogVersion := .Values.graylog.image.tag | default .Chart.AppVersion }}
-          {{- if semverCompare "< 4.2.0-0" ( $graylogVersion ) }}
           lifecycle:
             preStop:
               exec:
@@ -245,12 +238,10 @@ spec:
                   - bash
                   - -ec
                   - |
-                    ROOT_PASSWORD=`/k8s/kubectl get secret {{ template "graylog.fullname" . }} -o "jsonpath={.data['graylog-password-secret']}" | base64 -d`
                     curl {{ if .Values.graylog.tls.enabled }}-k{{ end }} -XPOST -sS \
-                      -u "{{ .Values.graylog.rootUsername }}:${ROOT_PASSWORD}" \
+                      -u "{{ .Values.graylog.rootUsername }}:${GRAYLOG_PASSWORD_SECRET}" \
                       -H "X-Requested-By: {{ template "graylog.fullname" . }}" \
                       {{ template "graylog.formatUrl" (list . "localhost:9000/api/system/shutdown/shutdown") }}
-          {{- end }}
       {{- if .Values.graylog.sidecarContainers }}
         {{ toYaml .Values.graylog.sidecarContainers | nindent 8 }}
       {{- end }}
@@ -278,8 +269,6 @@ spec:
           configMap:
             name: {{ template "graylog.fullname" . }}-files
         {{- end }}
-        - name: kubectl
-          emptyDir: {}
         {{- if .Values.graylog.extraVolumes }}
         {{ toYaml .Values.graylog.extraVolumes | nindent 8 }}
         {{- end }}

--- a/charts/graylog/templates/statefulset.yaml
+++ b/charts/graylog/templates/statefulset.yaml
@@ -231,17 +231,6 @@ spec:
           {{- if .Values.graylog.extraVolumeMounts }}
           {{ toYaml .Values.graylog.extraVolumeMounts | nindent 12 }}
           {{- end }}
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                  - bash
-                  - -ec
-                  - |
-                    curl {{ if .Values.graylog.tls.enabled }}-k{{ end }} -XPOST -sS \
-                      -u "{{ .Values.graylog.rootUsername }}:${GRAYLOG_PASSWORD_SECRET}" \
-                      -H "X-Requested-By: {{ template "graylog.fullname" . }}" \
-                      {{ template "graylog.formatUrl" (list . "localhost:9000/api/system/shutdown/shutdown") }}
       {{- if .Values.graylog.sidecarContainers }}
         {{ toYaml .Values.graylog.sidecarContainers | nindent 8 }}
       {{- end }}

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -502,13 +502,6 @@ graylog:
       repository: "alpine"
       pullPolicy: "IfNotPresent"
 
-    ## Set kubectl location to download and use on init-container. If the value is not set, the https://dl.k8s.io/release/ will be used.
-    ##
-    kubectlLocation: ""
-    ## Set kubectl command version to download from https://dl.k8s.io/release/. If the value is not set, default value is .Capabilities.KubeVersion.Version
-    ##
-    # kubectlVersion: "v1.20"
-
     # Additional environment variables to be added to Graylog initContainer
     env: {}
 


### PR DESCRIPTION
# What this PR does / why we need it

This cleans up the code in #154 - removing the kubectl volume, download and semver check

# Which issue this PR fixes

Graylog 6 adds a new data_dir requirement, which is set. I don't believe this will cause problems for older graylog

# Special notes for your reviewer

# Checklist
- [X] [DCO](https://github.com/KongZ/charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
