### PR TITLE
fix Pod graceful termination

### DIFF
--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 2.4.1
+version: 2.4.2
 appVersion: 6.3.3
 description: Graylog is the centralized log management solution built to open
   standards for capturing, storing, and enabling real-time analysis of terabytes

--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 2.4.3
+version: 2.4.4
 appVersion: 6.3.3
 description: Graylog is the centralized log management solution built to open
   standards for capturing, storing, and enabling real-time analysis of terabytes

--- a/charts/graylog/templates/configmap.yaml
+++ b/charts/graylog/templates/configmap.yaml
@@ -225,7 +225,7 @@ data:
     echo "Graylog Leader ${GRAYLOG_IS_LEADER}"
     echo "Graylog Plugin Dir ${GRAYLOG_PLUGIN_DIR}"
     echo "Graylog Elasticsearch Version ${GRAYLOG_ELASTICSEARCH_VERSION}"
-    "${JAVA_HOME}/bin/java" \
+    exec "${JAVA_HOME}/bin/java" \
       ${GRAYLOG_SERVER_JAVA_OPTS} \
       -jar \
       -Dlog4j.configurationFile=${GRAYLOG_HOME}/config/log4j2.xml \


### PR DESCRIPTION
# What this PR does / why we need it

Adds `exec` to the entrypoint script so that the Graylog server process becomes PID 1. This allows the server to gracefaully handle Pod termination signals and shutdown quickly. Without the `exec`, the shell script swallows the signal (does not pass to child processes) and the Pod is forcibly terminated after the `terminationGracePeriodSeconds` setting (usually 2 minutes).

Compare to the upstream entrypoint script which already uses `exec`: https://github.com/Graylog2/graylog-docker/blob/1d774e6623d1cf34fb2c6a8fc72e22ee75787218/docker-entrypoint.sh#L91-L99

Graylog server Pod log with fix showing graceful shutdown:

```text
{"instant":{"epochSecond":1758040439,"nanoOfSecond":194707442},"thread":"Thread-3","level":"INFO","loggerName":"org.graylog2.commands.Server","message":"SIGNAL received. Shutting down.","endOfBatch":false,"loggerFqcn":"org.apache.logging.slf4j.Log4jLogger","threadId":148,"threadPriority":5}
{"instant":{"epochSecond":1758040439,"nanoOfSecond":198652166},"thread":"Thread-3","level":"INFO","loggerName":"org.graylog2.system.shutdown.GracefulShutdown","message":"Graceful shutdown initiated.","endOfBatch":false,"loggerFqcn":"org.apache.logging.slf4j.Log4jLogger","threadId":148,"threadPriority":5}
```

There are no server logs without the graceful shutdown.

And k8s event logging, with fix, Pod is stopped and re-assigned in about 8 seconds:

```text
2025-09-16T16:33:59Z   2025-09-16T16:33:59Z   1       kubelet             Normal   Killing     Stopping container graylog-server
2025-09-16T16:34:07Z   2025-09-16T16:34:07Z   1       default-scheduler   Normal   Scheduled   Successfully assigned logging/graylog-2 to <redacted>
```

Compared to no fix, Pod is stopped and re-assigned in 2 minutes after termination grace period:

```text
2025-09-16T16:41:55Z   2025-09-16T16:41:55Z   1       kubelet             Normal    Killing     Stopping container graylog-server
2025-09-16T16:43:55Z   2025-09-16T16:43:55Z   1       default-scheduler   Normal    Scheduled   Successfully assigned logging/graylog-2 to <redacted>
```

# Which issue this PR fixes

none

# Special notes for your reviewer

none

# Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] [DCO](https://github.com/KongZ/charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
