### PR TITLE
replace mongodb

### DIFF
--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 2.5.0
+version: 3.0.0
 appVersion: 6.3.3
 description: Graylog is the centralized log management solution built to open
   standards for capturing, storing, and enabling real-time analysis of terabytes

--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 2.4.4
+version: 2.5.0
 appVersion: 6.3.3
 description: Graylog is the centralized log management solution built to open
   standards for capturing, storing, and enabling real-time analysis of terabytes
@@ -23,9 +23,9 @@ maintainers:
 dependencies:
   - tags:
       - install-mongodb
-    name: mongodb
-    version: 16.5.44
-    repository: https://charts.bitnami.com/bitnami
+    name: community-operator
+    version: 0.13.0
+    repository: https://mongodb.github.io/helm-charts
   - tags:
       - install-opensearch
     name: opensearch

--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -10,34 +10,84 @@ This chart requires the following charts before install Graylog
 1. MongoDB
 2. Opensearch
 
+Since chart version 2.5.0, we replaced Bitnami MongoDB with the official MongoDB image. You must manually install the MongoDB Operator CRD before installing the Graylog chart with dependencies. 
+
+Install MongoDB CRDs only first installation. You can skip CRD step when upgrade.
+
+```bash
+helm install --create-namespace --namespace graylog community-operator-crds mongodb/community-operator-crds 
+```
+
 To install the Graylog Chart with all dependencies
 
 ```bash
-kubectl create namespace graylog
-
-helm install --namespace "graylog" graylog kongz/graylog
+helm install --create-namespace --namespace graylog graylog kongz/graylog
 ```
 
 ## Manually Install Dependencies
 
 This method is _recommended_ when you want to expand the availability, scalability, and security of the services. You need to install MongoDB replicaset and Opensearch with proper settings before install Graylog.
 
-To install MongoDB, run
+### To install MongoDB, run
 
 ```bash
-helm install --namespace "graylog" mongodb bitnami/mongodb
+helm install --create-namespace --namespace graylog community-operator-crds mongodb/community-operator-crds
 ```
 
-Note: There are many alternative MongoDB available on [artifacthub.io](https://artifacthub.io/packages/search?page=1&ts_query_web=mongodb). If you found the `bitnami/mongodb` is not suitable, you can use another MongoDB chart. Modify `graylog.mongodb.uri` to match your MongoDB endpoint.
-
-To install Opensearch, run
+And then apply the following MongoDBCommunity manifest.
 
 ```bash
-helm install --namespace "graylog" opensearch elastic/opensearch
+kubectl apply -f <graylog-mongodb.yaml>
 ```
 
-The Opensearch installation command above will install all Opensearch
-nodes types in single node. It is strongly recommend to follow the Opensearch [guide](https://github.com/elastic/helm-charts/tree/main/epensearch#how-to-deploy-dedicated-nodes-types) to install dedicated node on production.
+The sample configuration for MongoDB setup for Graylog.
+
+```yaml
+apiVersion: mongodbcommunity.mongodb.com/v1
+kind: MongoDBCommunity
+metadata:
+  name: graylog-mongodb
+spec:
+  members: 3
+  security:
+    authentication:
+      modes: 
+        - SCRAM
+  type: ReplicaSet
+  users:
+    - db: graylog
+      name: graylog
+      passwordSecretRef:
+        name: graylog-mongodb
+      roles:
+      - db: graylog
+        name: readWrite
+      - db: admin
+        name: clusterMonitor
+      scramCredentialsSecretName: graylog
+  version: 6.0.25
+```
+
+For complete MongoDB Operator installation separately, see https://github.com/mongodb/mongodb-kubernetes-operator
+
+Note: There are many alternative MongoDB available on [artifacthub.io](https://artifacthub.io/packages/search?page=1&ts_query_web=mongodb). If you found the `mongodb community operator` is not suitable, you can use another MongoDB chart. Modify `graylog.mongodb.uri` to match your MongoDB endpoint.
+
+You can specify how Graylog picks the MongoDB connection in this order:
+
+* If `graylog.mongodb.uri` is specified, it will use this value.
+* If `graylog.mongodb.uriSecretKey` is specified, it will use the secret `graylog.mongodb.uriSecretName`.
+* If `mongodb.community.install` is `true` and neither `graylog.mongodb.uri` nor `graylog.mongodb.uriSecretKey` is used, it will use the secret generated from the MongoDB Operator.
+
+### To install Opensearch, run
+
+```bash
+helm repo add opensearch https://opensearch-project.github.io/helm-charts/
+
+helm install --namespace "graylog" opensearch opensearch/opensearch
+```
+
+The Opensearch installation command above will install all Opensearch nodes types in single node. 
+It is strongly recommend to follow the Opensearch [guide](https://docs.opensearch.org/latest/install-and-configure/install-opensearch/helm/) to install dedicated node on production.
 
 Note: There are many alternative Opensearch available on [artifacthub.io](https://artifacthub.io/packages/search?page=1&ts_query_web=Opensearch). If you found the `stable/opensearch` is not suitable, you can search other charts from GitHub repositories.
 
@@ -51,7 +101,6 @@ helm install --namespace "graylog" graylog kongz/graylog \
   --set tags.install-opensearch=false\
   --set graylog.mongodb.uri=mongodb://mongodb-mongodb-replicaset-0.mongodb-mongodb-replicaset.graylog.svc.cluster.local:27017/graylog?replicaSet=rs0 \
   --set graylog.opensearch.hosts=http://opensearch-cluster-master-headless.graylog.svc.cluster.local:9200
-  --set graylog.opensearch.version=7
 ```
 
 After installation succeeds, you can get a status of Chart
@@ -335,22 +384,10 @@ certificates can be added to `graylog.serverFiles` and you can configure the `gr
 Each Graylog node coordinates with each other through the DNS entry exposed via the headless service, so when generating
 the certificates, be sure to include a SAN entry for `*.graylog[-<suffix>].<namespace>.cluster.local` (or your configured FQDN).
 
-## Get Graylog status
+## Graylog Master Node
 
-You can get your Graylog status by running the command
-
-```bash
-kubectl get po -L graylog-role
-```
-
-Output
-
-```output
-NAME                        READY     STATUS    RESTARTS   AGE       graylog-ROLE
-graylog-0                   1/1       Running     0          1d        master
-graylog-1                   1/1       Running     0          1d        coordinating
-graylog-2                   1/1       Running     0          1m        coordinating
-```
+Since Graylog 6, the Graylog image hard-codes the image suffix `-0` as the master node.
+Dynamic master node selection is no longer necessary. You can always assume `graylog-0` as the master node or refer to the service `graylog-master.<namespace>.svc.cluster.local`
 
 ## Troubleshooting
 
@@ -360,6 +397,11 @@ You can do this automatically by setting `graylog.journal.deleteBeforeStart` to 
 The chart will delete all journal files before starting Graylog.
 
 Note: All uncommitted logs will be permanently DELETED when this value is true
+
+---
+
+If you are encounter "Failed to decrypt values from MongoDB. This means that your password_secret has been changed or there are some nodes in your cluster that are using a different password_secret to the one configured on this node. Secrets have to be configured to the same value on every node and can't be changed afterwards.", this mean that you may use password in Secret has been changed from previous deployment.
+
 
 [1]: https://www.graylog.org/
 [2]: https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/#actions

--- a/charts/graylog/templates/configmap.yaml
+++ b/charts/graylog/templates/configmap.yaml
@@ -26,7 +26,7 @@ data:
                 <DefaultRolloverStrategy max="10" fileIndex="min"/>
             </RollingFile>
             <!-- Internal Graylog log appender. Please do not disable. This makes internal log messages available via REST calls. -->
-            <Memory name="graylog-internal-logs" bufferSize="500"/>
+            <Memory name="graylog-internal-logs" bufferSizeBytes="50MB"/>
             <!-- Rotate audit logs daily -->
             <RollingFile name="AUDITLOG" fileName="/usr/share/graylog/log/audit.log" filePattern="/usr/share/graylog/log/audit-%d{yyyy-MM-dd}.log.gz">
                 <PatternLayout>
@@ -101,7 +101,6 @@ data:
   {{- end }}
     elasticsearch_hosts = {{ template "graylog.opensearch.hosts" . }}
     elasticsearch_discovery_enabled = false
-    # elasticsearch_disable_version_check = true
     allow_leading_wildcard_searches = {{ .Values.graylog.options.allowLeadingWildcardSearches }}
     allow_highlighting = {{ .Values.graylog.options.allowHighlighting }}
     output_batch_size = 500
@@ -124,7 +123,6 @@ data:
     message_journal_segment_size = {{ .Values.graylog.journal.segmentSize }}
     lb_recognition_period_seconds = 3
     # Use a replica set instead of a single host
-    mongodb_uri = {{ template "graylog.mongodb.uri" . }}
     mongodb_max_connections = {{ default 1000 .Values.graylog.mongodb.maxConnections }}
     mongodb_threads_allowed_to_block_multiplier = 5
     # Email transport
@@ -154,11 +152,11 @@ data:
     prometheus_exporter_bind_address = 0.0.0.0:9833
   {{- end }}
   {{- if .Values.graylog.trustedProxies }}
-    trusted_proxies = {{.Values.graylog.trustedProxies}}
+    trusted_proxies = {{ .Values.graylog.trustedProxies }}
   {{- end }}
     data_dir = /usr/share/graylog/data
   {{- if .Values.graylog.config }}
-{{ .Values.graylog.config | indent 4 }}
+    {{ .Values.graylog.config | nindent 4 }}
   {{- end }}
   entrypoint.sh: |-
     #!/usr/bin/env bash
@@ -218,13 +216,9 @@ data:
     # Interpolate
     sed 's/"/\\\"/g;s/.*/echo "&"/e' ${GRAYLOG_HOME}/config/graylog.conf > ${GRAYLOG_HOME}/graylog.conf.subst
   {{- end }}
-  {{- if .Values.graylog.opensearch.version }}
-    export GRAYLOG_ELASTICSEARCH_VERSION={{ .Values.graylog.opensearch.version }}
-  {{- end }}
     echo "Graylog Home ${GRAYLOG_HOME}"
     echo "Graylog Leader ${GRAYLOG_IS_LEADER}"
     echo "Graylog Plugin Dir ${GRAYLOG_PLUGIN_DIR}"
-    echo "Graylog Elasticsearch Version ${GRAYLOG_ELASTICSEARCH_VERSION}"
     exec "${JAVA_HOME}/bin/java" \
       ${GRAYLOG_SERVER_JAVA_OPTS} \
       -jar \

--- a/charts/graylog/templates/mongodb-community.yaml
+++ b/charts/graylog/templates/mongodb-community.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.mongodb.community.install }}
+apiVersion: mongodbcommunity.mongodb.com/v1
+kind: MongoDBCommunity
+metadata:
+  name: {{ include "graylog.mongodb.name" . }}
+spec:
+  members: {{ .Values.mongodb.community.replicas }}
+  type: ReplicaSet
+  version: {{ .Values.mongodb.community.version | quote}}
+  security:
+    authentication:
+      modes: ["SCRAM"] # Standard password authentication
+  users:
+    - name: {{ .Values.mongodb.community.auth.user }}
+      db: graylog
+      passwordSecretRef:
+        # This secret will be created by the operator
+        name: {{ include "graylog.mongodb.name" . }}
+      roles:
+        - name: readWrite
+          db: graylog
+        - name: clusterMonitor
+          db: admin
+      scramCredentialsSecretName: graylog
+  additionalConnectionStringConfig:
+    authSource: "graylog"
+    connectTimeoutMS: "300000"
+  statefulSet:
+    spec:
+      volumeClaimTemplates:
+        - metadata:
+            name: data-volume
+          spec:
+            resources:
+              requests:
+                storage: {{ .Values.mongodb.persistence.size }}
+---
+{{- $password := include "graylog.mongodb.auth.password" . }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "graylog.mongodb.name" . }}
+type: Opaque
+stringData:
+  password: {{ $password | quote }}
+{{- end }}

--- a/charts/graylog/templates/secret.yaml
+++ b/charts/graylog/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "graylog.fullname" . }}
+  name: {{ include "graylog.fullname" . }}
   labels:
 {{ include "graylog.metadataLabels" . | indent 4 }}
 {{- if .Values.graylog.secret.annotations }}
@@ -12,12 +12,7 @@ metadata:
 type: Opaque
 data:
   graylog-root-username: {{ .Values.graylog.rootUsername | b64enc | quote }}
-  {{- if .Values.graylog.rootPassword }}
-  graylog-password-secret: {{ .Values.graylog.rootPassword | b64enc | quote }}
-  graylog-password-sha2: {{ .Values.graylog.rootPassword | sha256sum | b64enc | quote }}
-  {{- else }}
-  {{- $randpass := randAlphaNum 16 }}
-  graylog-password-secret: {{ $randpass | b64enc | quote }}
-  graylog-password-sha2: {{ $randpass | sha256sum | b64enc | quote }}
-  {{- end }}
+  {{- $password := (include "graylog.password" .) }}
+  graylog-password-secret: {{ $password | b64enc | quote }}
+  graylog-password-sha2: {{ $password | sha256sum | b64enc | quote }}
 {{- end }}

--- a/charts/graylog/templates/statefulset.yaml
+++ b/charts/graylog/templates/statefulset.yaml
@@ -109,7 +109,7 @@ spec:
             - name: GRAYLOG_SERVER_JAVA_OPTS
               {{- $javaOpts := .Values.graylog.javaOpts }}
               {{- if .Values.graylog.heapSize }}
-              value: "{{ $javaOpts }} {{ printf "-Xms%s -Xmx%s" .Values.graylog.heapSize .Values.graylog.heapSize}}"
+              value: "{{ $javaOpts }} {{ printf "-Xms%s -Xmx%s" .Values.graylog.heapSize .Values.graylog.heapSize }}"
               {{- else }}
               value: "{{ $javaOpts }} -XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport"
               {{- end }}
@@ -130,12 +130,23 @@ spec:
                   name: {{ .Values.graylog.opensearch.uriSecretName | default (printf "%s-es" (include "graylog.fullname" .)) }}
                   key: {{ .Values.graylog.opensearch.uriSecretKey }}
             {{- end }}
-            {{- if .Values.graylog.mongodb.uriSecretKey }}
+            {{- if .Values.graylog.mongodb.uri }}
+            - name: GRAYLOG_MONGODB_URI
+              value: {{ .Values.graylog.mongodb.uri | quote }}
+            {{- else if .Values.graylog.mongodb.uriSecretKey }}
             - name: GRAYLOG_MONGODB_URI
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.graylog.mongodb.uriSecretName | default (printf "%s-mongodb" (include "graylog.fullname" .)) }}
-                  key: {{ .Values.graylog.mongodb.uriSecretKey }}
+                  key: {{ .Values.graylog.mongodb.uriSecretKey | default "connectionString" }}
+            {{- else if .Values.mongodb.community.install }}
+            - name: GRAYLOG_MONGODB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "graylog.mongodb.name" . }}-graylog-graylog # format: <metadata.name>-<auth-db>-<username>
+                  key: connectionString.standard
+            {{- end }}
+            {{- if .Values.graylog.trustedProxies }}
             {{- end }}
             {{- range $key, $value := .Values.graylog.env }}
             - name: {{ $key }}

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -2,6 +2,14 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+## This will override the name of the application.
+##
+nameOverride: ""
+
+## This will override the release name of the application using in all resources.
+##
+fullnameOverride: ""
+
 rbac:
   # Specifies whether RBAC resources should be created
   ##
@@ -12,11 +20,11 @@ rbac:
     - secrets
 
 serviceAccount:
-  # Specifies whether a ServiceAccount should be created
+  ## Specifies whether a ServiceAccount should be created
   ##
   create: true
-  # The name of the ServiceAccount to use.
-  # If not set and create is true, a name is generated using the fullname template
+  ## The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the fullname template
   ##
   name:
 
@@ -25,9 +33,9 @@ serviceAccount:
   annotations: {}
 
 tags:
-  # If true, this chart will install opensearch from requirement dependencies
+  ## If true, this chart will install opensearch from requirement dependencies
   install-opensearch: true
-  # If true, this chart will install MongoDB replicaset from requirement dependencies
+  ## If true, this chart will install MongoDB replicaset from requirement dependencies
   install-mongodb: true
 
 ## Enable only if your current release was migrated from helm2 (using 2to3 plugin).
@@ -109,7 +117,7 @@ graylog:
 
   ## If specified, indicates the pod's priority.
   ##
-  # priorityClassName:
+  priorityClassName: ""
 
   ## Set security context for defining privilege and accessing control settings entire Pod
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -155,7 +163,7 @@ graylog:
     ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
     ##   GKE, AWS & OpenStack)
     ##
-    # storageClass: "ssd"
+    storageClass: ""
 
   ## Additional plugins you need to install on Graylog.
   ##
@@ -243,7 +251,7 @@ graylog:
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-http-request
   ##
   livenessProbe:
-    initialDelaySeconds: 0
+    initialDelaySeconds: 30
     periodSeconds: 30
     failureThreshold: 3
     successThreshold: 1
@@ -253,7 +261,7 @@ graylog:
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-http-request
   ##
   readinessProbe:
-    initialDelaySeconds: 0
+    initialDelaySeconds: 30
     periodSeconds: 10
     failureThreshold: 3
     successThreshold: 1
@@ -420,7 +428,7 @@ graylog:
   ## Graylog root password
   ## Defaults to a random 16-character alphanumeric string if not set
   ##
-  # rootPassword: ""
+  rootPassword: ""
 
   ## Graylog root email
   ##
@@ -439,10 +447,6 @@ graylog:
   httpEnableCors: false
 
   opensearch:
-    ## Major version of the Elasticsearch version used.
-    ## It is required by Graylog 4. See https://docs.graylog.org/en/4.0/pages/configuration/elasticsearch.html#available-elasticsearch-configuration-tunables
-    # version: "7"
-
     ## List of Elasticsearch hosts Graylog should connect to.
     ## Need to be specified as a comma-separated list of valid URIs for the http ports of your elasticsearch nodes.
     ## If one or more of your elasticsearch hosts require authentication, include the credentials in each node URI that
@@ -461,10 +465,15 @@ graylog:
   mongodb:
     ## MongoDB connection string
     ## See https://docs.mongodb.com/manual/reference/connection-string/ for details
+    ##
+    ## If you install MongoDB using this chart by set mongodb.community.install=true, you can leave this value blank
+    ## Chart will pick up the connection URL from mongodb community operator.
+    ## If you have your own MongoDB server, you need to set this value or set uriSecretName and uriSecretKey to fetch the
+    ## connection string from a k8s secret.
+    ##
     # uri: mongodb://user:pass@host1:27017,host2:27017,host3:27017/graylog?replicaSet=rs01
     uri: ""
     # Allow mongodb uri to be fetched from a k8s secret
-    # {{ graylog.fullname }}-headless will be used as uriSecretName if left empty
     uriSecretName: ""
     uriSecretKey: ""
 
@@ -492,10 +501,16 @@ graylog:
   ## You can find a complete list of graylog config from http://docs.graylog.org/en/3.0/pages/configuration/server.conf.html
   ## Graylog config is written in Java properites format. Make sure you write it correctly.
   ##
+  config: ""
   # config: |
   #   elasticsearch_connect_timeout = 10s
   #   elasticsearch_socket_timeout = 60s
   #   elasticsearch_idle_timeout = -1s
+
+  ## Configure the source IP address of the proxies to accept the Remote-User header from a proxy and enable successful authentication.
+  ## Ref: https://go2docs.graylog.org/current/setting_up_graylog/trusted_header_authentication.htm
+  ##
+  trustedProxies: ""
 
   journal:
     ## Enable the disk-based message journal.
@@ -642,20 +657,28 @@ opensearch:
   #     requests:
   #       storage: 30Gi # default 30Gi
 
-# Specify Mongodb settings. Ignore this section if you install MongoDB manually.
-#
+## Specify Mongodb settings. Ignore this section if you install MongoDB manually.
+##
 mongodb:
-  ## Default Bitnami MongoDB image in the chart does not support Arm64 architecture.
-  ## Uncomment the following section `image` and `global.security.allowInsecureImages` to use another Bitnami MongoDB image.
-  ##
-  # image:
-  #   repository: bitnamisecure/mongodb
-  #   tag: latest
-  # global:
-  #   security:
-  #     allowInsecureImages: true
-  architecture: "replicaset"
-  useStatefulSet: true
-  replicaCount: 1
-  auth:
+  community:
+    ## If true, MongoDB Community will be installed
+    ##
+    install: true
+    replicas: 3
+    version: "6.0.25"
+    auth:
+      user: "graylog"
+      ## If empty, a random 20-character alphanumeric string will be generated
+      password: ""
+  persistence:
+    size: "8Gi"
+
+## IMPORTANT! Official MongoDB chart requires CRD to be installed first before installing the MongoDB replicaset.
+##
+community-operator:
+  community-operator-crds:
+    ## If true, MongoDB Community Operator CRDs will be installed.
+    ## It is strongly recommended to install the CRDs manually before installing the MongoDB replicaset.
+    ## Using dependencies is not order guaranteed and may cause the MongoDB replicaset installation to fail.
+    ##
     enabled: false


### PR DESCRIPTION
# What this PR does / why we need it

* SiOnce the Bitnami MongoDB is no longer available, I have replaced it with the official MongoDB chart and image. https://mongodb.github.io/helm-charts uses the operator pattern and requires a CRD. You will need to take an additional step to install the CRD one time before deploying the Graylog.

```bash
helm install --create-namespace --namespace graylog community-operator-crds mongodb/community-operator-crds
```

*NOTE*: This change is not compatible with previous chart 2.x version due to the change in MongoDB.

If you want to use chart version 2.x with Bitnami MongoDB, try setting values to

```
mongodb:
  image:
    repository: bitnamisecure/mongodb
    tag: latest
  global:
    security:
      allowInsecureImages: true
```

* Fixed the problem when using helm upgrade with a random password generator. The random password will regenerate a new password every time when helm upgrade. This PR uses a lookup method to preserve the original password without regenerating it. But it requires the user to have read Secret permission.

# Which issue this PR fixes

- fixes #185, #186 

# Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] [DCO](https://github.com/KongZ/charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
