### PR TITLE
fix coalesce warning due to envRaw type mismatch

### DIFF
--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -89,7 +89,7 @@ graylog:
   ##       fieldPath: status.podIP
   ## - name: SERVICE_8000_NAME
   ##   value: servicename
-  envRaw: {}
+  envRaw: []
 
   ## Pod affinity
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/KongZ/charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->

# What this PR does / why we need it
There is a mismatch in the default values file:
```
 ## Additional environment variables in raw yaml format
  ## - name: POD_IP
  ##   valueFrom:
  ##     fieldRef:
  ##       fieldPath: status.podIP
  ## - name: SERVICE_8000_NAME
  ##   value: servicename
  envRaw: {}
  ```
The example shows a list-style (correct), but the default value is an empty map {} (incorrect).

This creates a type inconsistency when templating.   Helm sees `envRaw` as a map by default, but the template logic is written to handle a YAML block/list when values are supplied.  This results in a warning message such as  `coalesce.go:298: warning: cannot overwrite table with non table` when helm tries to merge a list into an existing map key.
  
  
# Which issue this PR fixes

_(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)_

- fixes #

# Special notes for your reviewer

To reproduce, create a `my-values.yaml` file containing a sample envRaw such as:
```
graylog:
  envRaw:
    - name: MY_VAR
      value: my_value
```

Temple and write to a file.
```
helm template . --values my-values.yaml > graylog-templated.yaml
coalesce.go:298: warning: cannot overwrite table with non table for graylog.graylog.envRaw (map[])
coalesce.go:298: warning: cannot overwrite table with non table for graylog.graylog.envRaw (map[])
```

# Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] [DCO](https://github.com/KongZ/charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
