### PR TITLE
MongoDB logs-volume size

### DIFF
--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 3.0.12
+version: 3.0.13
 appVersion: 7.0.4
 description: Graylog is the centralized log management solution built to open
   standards for capturing, storing, and enabling real-time analysis of terabytes

--- a/charts/graylog/templates/mongodb-community.yaml
+++ b/charts/graylog/templates/mongodb-community.yaml
@@ -57,6 +57,14 @@ spec:
             resources:
               requests:
                 storage: {{ .Values.mongodb.persistence.size }}
+        {{- if .Values.mongodb.persistence.logsSize }}
+        - metadata:
+            name: logs-volume
+          spec:
+            resources:
+              requests:
+                storage: {{ .Values.mongodb.persistence.logsSize }}
+        {{- end }}
 ---
 {{- $password := include "graylog.mongodb.auth.password" . }}
 apiVersion: v1

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -691,6 +691,7 @@ mongodb:
     #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
   persistence:
     size: "8Gi"
+    #logsSize: "2Gi"
 
   ## Configure MongoDB containers
   containers: []


### PR DESCRIPTION
<!--
Thank you for contributing!
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/KongZ/charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->

# What this PR does / why we need it

Add ability to set MongoDB logs volume size.
By default logs-volume size = `2G` (2000000000 bytes) but some cloud volume provisioners requires volume size aligned to cluster size (4096 bytes for example).


# Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] [DCO](https://github.com/KongZ/charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
