### PR TITLE
support gateway api

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -39,5 +39,6 @@ jobs:
           VALIDATE_NATURAL_LANGUAGE: false
           VALIDATE_CHECKOV: false
           VALIDATE_YAML_PRETTIER: false
+          VALIDATE_MARKDOWN_PRETTIER: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: graylog
 home: https://www.graylog.org
-version: 3.0.16
+version: 3.0.17
 appVersion: 7.0.5
 description: Graylog is the centralized log management solution built to open
   standards for capturing, storing, and enabling real-time analysis of terabytes

--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -492,8 +492,8 @@ Note: All uncommitted logs will be permanently DELETED when this value is true
 
 ---
 
-If you are encounter "Failed to decrypt values from MongoDB. 
-This means that your password_secret has been changed or there are some nodes in your cluster that are using a different password_secret to the one configured on this node. 
+If you are encounter "Failed to decrypt values from MongoDB.
+This means that your password_secret has been changed or there are some nodes in your cluster that are using a different password_secret to the one configured on this node.
 Secrets have to be configured to the same value on every node and can't be changed afterwards.", this mean that you may use password in Secret has been changed from previous deployment.
 
 

--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -208,7 +208,18 @@ The following table lists the configurable parameters of the Graylog chart and t
 | `graylog.ingress.extraPaths`                      | Ingress extra paths to prepend to every host configuration. Useful when configuring [custom actions with AWS ALB Ingress Controller][2].        | `[]`                              |
 | `graylog.input`                                   | Graylog Input configuration (YAML) Sees #Input section for detail                                                                               | `{}`                              |
 | `graylog.input.tcp.service.name`                  | Graylog TCP Input service name                                                                                                                  | `graylog-tcp`                     |
+| `graylog.input.tcp.gatewayApi.enabled`            | If true, a TCPRoute (gateway.networking.k8s.io/v1alpha2) is created for each TCP input port. Requires Gateway API experimental CRDs.           | `false`                           |
+| `graylog.input.tcp.gatewayApi.parentRefs`         | List of Gateway parentRefs for the TCPRoute. At least one entry is required when enabled. Each entry: `name`, optional `namespace`/`sectionName` | `[]`                              |
 | `graylog.input.udp.service.name`                  | Graylog UDP Input service name                                                                                                                  | `graylog-udp`                     |
+| `graylog.input.udp.gatewayApi.enabled`            | If true, a UDPRoute (gateway.networking.k8s.io/v1alpha2) is created for each UDP input port. Requires Gateway API experimental CRDs.           | `false`                           |
+| `graylog.input.udp.gatewayApi.parentRefs`         | List of Gateway parentRefs for the UDPRoute. At least one entry is required when enabled. Each entry: `name`, optional `namespace`/`sectionName` | `[]`                              |
+| `graylog.gatewayApi.enabled`                      | If true, an HTTPRoute (gateway.networking.k8s.io/v1) is created for the Graylog web UI. Requires Gateway API standard CRDs.                    | `false`                           |
+| `graylog.gatewayApi.annotations`                  | HTTPRoute annotations                                                                                                                           | `{}`                              |
+| `graylog.gatewayApi.labels`                       | HTTPRoute extra labels                                                                                                                          | `{}`                              |
+| `graylog.gatewayApi.parentRefs`                   | List of Gateway parentRefs for the HTTPRoute. At least one entry is required when enabled. Each entry: `name`, optional `namespace`/`sectionName` | `[]`                              |
+| `graylog.gatewayApi.hosts`                        | Hostnames to match. Note: Graylog does not support multiple URLs — specify a single hostname.                                                   | `[]`                              |
+| `graylog.gatewayApi.pathType`                     | HTTPRoute path match type (`PathPrefix` or `Exact`)                                                                                             | `PathPrefix`                      |
+| `graylog.gatewayApi.path`                         | HTTPRoute path                                                                                                                                  | `/`                               |
 | `graylog.metrics.enabled`                         | If true, add Prometheus annotations to pods                                                                                                     | `false`                           |
 | `graylog.metrics.serviceMonitor.enabled`          | If true, a ServiceMonitor resource for the prometheus-operator is created                                                                       | `false`                           |
 | `graylog.metrics.serviceMonitor.additionalLabels` | ServiceMonitor additional Labels                                                                                                                | `false`                           |
@@ -335,6 +346,82 @@ service:
 Note: Name must be in **IANA_SVC_NAME** format - at most 15 characters, matching regex **[a-z0-9]**, containing at least one letter, and hyphens cannot be adjacent to other hyphens
 
 Note: The port list should be sorted by port number.
+
+## Gateway API
+
+The chart supports [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/) as an alternative to `Ingress` and `LoadBalancer` services.
+
+| Resource | API version | Controls |
+|---|---|---|
+| `HTTPRoute` | `gateway.networking.k8s.io/v1` (standard, GA) | Graylog web UI (port 9000) |
+| `TCPRoute` | `gateway.networking.k8s.io/v1alpha2` (experimental) | TCP inputs (GELF, Beats, etc.) |
+| `UDPRoute` | `gateway.networking.k8s.io/v1alpha2` (experimental) | UDP inputs (syslog, etc.) |
+
+The standard CRDs must be installed for HTTPRoute; the experimental CRDs are additionally required for TCPRoute/UDPRoute. The chart will fail with a clear error message if the relevant CRDs are missing when a route is enabled.
+
+### HTTPRoute (web UI)
+
+```yaml
+graylog:
+  gatewayApi:
+    enabled: true
+    parentRefs:
+      - name: my-gateway
+        namespace: gateway-system
+        sectionName: https   # optional: target a specific listener
+    hosts:
+      - graylog.yourdomain.com
+    pathType: PathPrefix
+    path: /
+```
+
+TLS is handled at the `Gateway` listener level, not in the HTTPRoute.
+
+### TCPRoute / UDPRoute (log inputs)
+
+When using Gateway API for inputs, set the input service type to `ClusterIP` — the Gateway handles external exposure instead of a `LoadBalancer`.
+
+One `TCPRoute` (or `UDPRoute`) is created **per port**. The `sectionName` in `parentRefs` defaults to the port's `name`, so Gateway listeners should be named to match.
+
+```yaml
+graylog:
+  input:
+    tcp:
+      service:
+        type: ClusterIP
+      gatewayApi:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+            namespace: gateway-system
+            # sectionName defaults to port name ("gelf")
+      ports:
+        - name: gelf
+          port: 12222
+    udp:
+      service:
+        type: ClusterIP
+      gatewayApi:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+            namespace: gateway-system
+      ports:
+        - name: syslog
+          port: 5410
+```
+
+The corresponding Gateway listeners (managed separately from this chart):
+
+```yaml
+listeners:
+  - name: gelf      # matches sectionName default for the "gelf" port
+    port: 12222
+    protocol: TCP
+  - name: syslog    # matches sectionName default for the "syslog" port
+    port: 5410
+    protocol: UDP
+```
 
 ## TLS
 

--- a/charts/graylog/templates/httproute.yaml
+++ b/charts/graylog/templates/httproute.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.graylog.gatewayApi.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+  {{- range $key, $value := .Values.graylog.gatewayApi.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  labels:
+{{ include "graylog.metadataLabels" . | indent 4 }}
+    app.kubernetes.io/component: "web"
+{{- if .Values.graylog.gatewayApi.labels }}
+{{ toYaml .Values.graylog.gatewayApi.labels | indent 4 }}
+{{- end }}
+  name: {{ template "graylog.fullname" . }}-web
+spec:
+  parentRefs:
+  {{- range .Values.graylog.gatewayApi.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName }}
+      {{- end }}
+  {{- end }}
+  {{- if .Values.graylog.gatewayApi.hosts }}
+  hostnames:
+  {{- range .Values.graylog.gatewayApi.hosts }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: {{ default "PathPrefix" .Values.graylog.gatewayApi.pathType }}
+            value: {{ default "/" .Values.graylog.gatewayApi.path }}
+      backendRefs:
+        - name: {{ template "graylog.fullname" . }}-web
+          port: {{ default 9000 .Values.graylog.service.port }}
+{{- end }}

--- a/charts/graylog/templates/httproute.yaml
+++ b/charts/graylog/templates/httproute.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.graylog.gatewayApi.enabled }}
+{{- if not (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1/HTTPRoute") }}
+  {{- fail "graylog.gatewayApi.enabled is true but the Gateway API CRD (gateway.networking.k8s.io/v1/HTTPRoute) is not installed on this cluster. Install the Gateway API CRDs first or set graylog.gatewayApi.enabled=false." }}
+{{- end }}
+{{- if empty .Values.graylog.gatewayApi.parentRefs }}
+  {{- fail "graylog.gatewayApi.enabled is true but graylog.gatewayApi.parentRefs is empty. Specify at least one parentRef pointing to a Gateway resource." }}
+{{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/charts/graylog/templates/tcproute.yaml
+++ b/charts/graylog/templates/tcproute.yaml
@@ -16,6 +16,7 @@ metadata:
 {{ include "graylog.metadataLabels" $ | indent 4 }}
     app.kubernetes.io/component: "TCP"
   name: {{ template "graylog.fullname" $ }}-tcp-{{ .name }}
+# jscpd:ignore-start
 spec:
   parentRefs:
   {{- range $.Values.graylog.input.tcp.gatewayApi.parentRefs }}
@@ -25,12 +26,11 @@ spec:
       {{- end }}
       sectionName: {{ default $port.name .sectionName }}
   {{- end }}
-  # jscpd:ignore-start
   rules:
     - backendRefs:
         - name: {{ if $.Values.graylog.input.tcp.service.name }}{{ $.Values.graylog.input.tcp.service.name }}{{ else }}{{ template "graylog.fullname" $ }}-tcp{{ end }}
           port: {{ .port }}
-  # jscpd:ignore-end
+# jscpd:ignore-end
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/graylog/templates/tcproute.yaml
+++ b/charts/graylog/templates/tcproute.yaml
@@ -25,10 +25,12 @@ spec:
       {{- end }}
       sectionName: {{ default $port.name .sectionName }}
   {{- end }}
+  # jscpd:ignore-start
   rules:
     - backendRefs:
         - name: {{ if $.Values.graylog.input.tcp.service.name }}{{ $.Values.graylog.input.tcp.service.name }}{{ else }}{{ template "graylog.fullname" $ }}-tcp{{ end }}
           port: {{ .port }}
+  # jscpd:ignore-end
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/graylog/templates/tcproute.yaml
+++ b/charts/graylog/templates/tcproute.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.graylog.input.tcp .Values.graylog.input.tcp.gatewayApi }}
+{{- if .Values.graylog.input.tcp.gatewayApi.enabled }}
+{{- range .Values.graylog.input.tcp.ports }}
+{{- $port := . }}
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  labels:
+{{ include "graylog.metadataLabels" $ | indent 4 }}
+    app.kubernetes.io/component: "TCP"
+  name: {{ template "graylog.fullname" $ }}-tcp-{{ .name }}
+spec:
+  parentRefs:
+  {{- range $.Values.graylog.input.tcp.gatewayApi.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+      sectionName: {{ default $port.name .sectionName }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ if $.Values.graylog.input.tcp.service.name }}{{ $.Values.graylog.input.tcp.service.name }}{{ else }}{{ template "graylog.fullname" $ }}-tcp{{ end }}
+          port: {{ .port }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/graylog/templates/tcproute.yaml
+++ b/charts/graylog/templates/tcproute.yaml
@@ -1,5 +1,11 @@
 {{- if and .Values.graylog.input.tcp .Values.graylog.input.tcp.gatewayApi }}
 {{- if .Values.graylog.input.tcp.gatewayApi.enabled }}
+{{- if not (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1alpha2/TCPRoute") }}
+  {{- fail "graylog.input.tcp.gatewayApi.enabled is true but the Gateway API CRD (gateway.networking.k8s.io/v1alpha2/TCPRoute) is not installed on this cluster. Install the Gateway API experimental CRDs first or set graylog.input.tcp.gatewayApi.enabled=false." }}
+{{- end }}
+{{- if empty .Values.graylog.input.tcp.gatewayApi.parentRefs }}
+  {{- fail "graylog.input.tcp.gatewayApi.enabled is true but graylog.input.tcp.gatewayApi.parentRefs is empty. Specify at least one parentRef pointing to a Gateway resource." }}
+{{- end }}
 {{- range .Values.graylog.input.tcp.ports }}
 {{- $port := . }}
 ---

--- a/charts/graylog/templates/udproute.yaml
+++ b/charts/graylog/templates/udproute.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.graylog.input.udp .Values.graylog.input.udp.gatewayApi }}
+{{- if .Values.graylog.input.udp.gatewayApi.enabled }}
+{{- range .Values.graylog.input.udp.ports }}
+{{- $port := . }}
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: UDPRoute
+metadata:
+  labels:
+{{ include "graylog.metadataLabels" $ | indent 4 }}
+    app.kubernetes.io/component: "UDP"
+  name: {{ template "graylog.fullname" $ }}-udp-{{ .name }}
+spec:
+  parentRefs:
+  {{- range $.Values.graylog.input.udp.gatewayApi.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+      sectionName: {{ default $port.name .sectionName }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ if $.Values.graylog.input.udp.service.name }}{{ $.Values.graylog.input.udp.service.name }}{{ else }}{{ template "graylog.fullname" $ }}-udp{{ end }}
+          port: {{ .port }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/graylog/templates/udproute.yaml
+++ b/charts/graylog/templates/udproute.yaml
@@ -25,10 +25,12 @@ spec:
       {{- end }}
       sectionName: {{ default $port.name .sectionName }}
   {{- end }}
+  # jscpd:ignore-start
   rules:
     - backendRefs:
         - name: {{ if $.Values.graylog.input.udp.service.name }}{{ $.Values.graylog.input.udp.service.name }}{{ else }}{{ template "graylog.fullname" $ }}-udp{{ end }}
           port: {{ .port }}
+  # jscpd:ignore-end
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/graylog/templates/udproute.yaml
+++ b/charts/graylog/templates/udproute.yaml
@@ -16,6 +16,7 @@ metadata:
 {{ include "graylog.metadataLabels" $ | indent 4 }}
     app.kubernetes.io/component: "UDP"
   name: {{ template "graylog.fullname" $ }}-udp-{{ .name }}
+# jscpd:ignore-start
 spec:
   parentRefs:
   {{- range $.Values.graylog.input.udp.gatewayApi.parentRefs }}
@@ -25,12 +26,11 @@ spec:
       {{- end }}
       sectionName: {{ default $port.name .sectionName }}
   {{- end }}
-  # jscpd:ignore-start
   rules:
     - backendRefs:
         - name: {{ if $.Values.graylog.input.udp.service.name }}{{ $.Values.graylog.input.udp.service.name }}{{ else }}{{ template "graylog.fullname" $ }}-udp{{ end }}
           port: {{ .port }}
-  # jscpd:ignore-end
+# jscpd:ignore-end
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/graylog/templates/udproute.yaml
+++ b/charts/graylog/templates/udproute.yaml
@@ -1,5 +1,11 @@
 {{- if and .Values.graylog.input.udp .Values.graylog.input.udp.gatewayApi }}
 {{- if .Values.graylog.input.udp.gatewayApi.enabled }}
+{{- if not (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1alpha2/UDPRoute") }}
+  {{- fail "graylog.input.udp.gatewayApi.enabled is true but the Gateway API CRD (gateway.networking.k8s.io/v1alpha2/UDPRoute) is not installed on this cluster. Install the Gateway API experimental CRDs first or set graylog.input.udp.gatewayApi.enabled=false." }}
+{{- end }}
+{{- if empty .Values.graylog.input.udp.gatewayApi.parentRefs }}
+  {{- fail "graylog.input.udp.gatewayApi.enabled is true but graylog.input.udp.gatewayApi.parentRefs is empty. Specify at least one parentRef pointing to a Gateway resource." }}
+{{- end }}
 {{- range .Values.graylog.input.udp.ports }}
 {{- $port := . }}
 ---

--- a/charts/graylog/values.yaml
+++ b/charts/graylog/values.yaml
@@ -277,6 +277,15 @@ graylog:
     #     type: LoadBalancer
     #     loadBalancerIP:
     #     trafficDistribution:
+    #   ## Kubernetes Gateway API TCPRoute (gateway.networking.k8s.io/v1alpha2)
+    #   ## Creates one TCPRoute per port entry. Requires a Gateway with matching listeners.
+    #   ## When enabled, consider using service.type: ClusterIP instead of LoadBalancer.
+    #   gatewayApi:
+    #     enabled: false
+    #     parentRefs:
+    #       - name: my-gateway
+    #         namespace: gateway-system
+    #         sectionName: gelf   # optional: overrides default (port name) for all ports
     #   ports:
     #     - name: gelf
     #       port: 12222
@@ -285,6 +294,15 @@ graylog:
     #     name: your-udp-service-name
     #     type: ClusterIP
     #     trafficDistribution:
+    #   ## Kubernetes Gateway API UDPRoute (gateway.networking.k8s.io/v1alpha2)
+    #   ## Creates one UDPRoute per port entry. Requires a Gateway with matching listeners.
+    #   ## When enabled, consider using service.type: ClusterIP instead of LoadBalancer.
+    #   gatewayApi:
+    #     enabled: false
+    #     parentRefs:
+    #       - name: my-gateway
+    #         namespace: gateway-system
+    #         sectionName: syslog   # optional: overrides default (port name) for all ports
     #   ports:
     #     - name: syslog
     #       port: 12222
@@ -367,6 +385,37 @@ graylog:
     ## Please note that tls secret should reside in istio-system namespace
     ## leave blanc for disabling TLS
     tlsSecretName: ""
+
+  gatewayApi:
+    ## If true, an HTTPRoute resource will be created for Kubernetes Gateway API
+    ##
+    enabled: false
+
+    ## HTTPRoute annotations
+    annotations: {}
+
+    ## HTTPRoute labels
+    labels: {}
+
+    ## Gateway parentRefs — reference the Gateway resource(s) this route attaches to
+    ## Must be provided if gatewayApi is enabled
+    ##
+    parentRefs: []
+    #  - name: my-gateway
+    #    namespace: gateway-system
+    #    sectionName: https   # optional: target a specific listener by name
+
+    ## Hostnames to match. Note: Graylog does not support multiple URLs.
+    ## Specify a single hostname.
+    ##
+    hosts: []
+    #  - graylog.yourdomain.com
+
+    ## Path type: PathPrefix or Exact
+    pathType: PathPrefix
+
+    ## URL path
+    path: /
 
   ## Configure resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
# What this PR does / why we need it

Add support for the Gateway API on ingress and TCP/UDP services.
This hasn’t been tested in a real Kubernetes cluster with Gateway API support.
Only tested with `helm template` commands

|#| Test | Result |
|-- | -- | --|
|1 | No route resources with defaults | ✅|
|2 | HTTPRoute renders correctly | ✅|
|3 | TCPRoute generates one resource per port | ✅|
|4 | Existing Ingress unaffected | ✅|
|5 | Full render with everything enabled | ✅|


# Which issue this PR fixes
#204 

# Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] [DCO](https://github.com/KongZ/charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
